### PR TITLE
Remove rmf alias

### DIFF
--- a/config/.zsh/aliases.zsh
+++ b/config/.zsh/aliases.zsh
@@ -6,7 +6,6 @@ alias mkdir='mkdir -p'
 alias ls='ls -l -a'
 alias fd='fd -H'
 alias valec='AWS_SDK_LOAD_CONFIG=1 valec'
-alias rmf='rm $(fd|fzf)'
 alias lg='lazygit'
 alias cl='claude'
 


### PR DESCRIPTION
## Summary
- Remove the `rmf` alias from zsh configuration

## Test plan
- [ ] Verify the alias is no longer available after sourcing the configuration
- [ ] Confirm no other parts of the dotfiles depend on this alias

🤖 Generated with [Claude Code](https://claude.ai/code)