### PR TITLE
feat: sesh + zoxide で tmux のセッション切り替えを強化する

### DIFF
--- a/config/.zshrc
+++ b/config/.zshrc
@@ -5,4 +5,5 @@ source ~/.zsh/basic.zsh
 source ~/.zsh/functions.zsh
 source ~/.zsh/completions.zsh
 
+eval "$(zoxide init zsh)"
 eval "$(starship init zsh)"

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -39,6 +39,7 @@
     coreutils
     libffi
     nnn
+    zoxide
     awscli2
     luarocks
     libpq

--- a/nix/programs/tmux.nix
+++ b/nix/programs/tmux.nix
@@ -74,7 +74,13 @@
       run-shell ${pkgs.tmuxPlugins.online-status.rtp}
 
       bind v split-window -h -c "#{pane_current_path}"
-      bind s split-window -v -c "#{pane_current_path}"
+      bind "|" split-window -h -c "#{pane_current_path}"
+      bind "-" split-window -v -c "#{pane_current_path}"
+
+      unbind s
+      bind S choose-tree -Zs
+
+      bind T run-shell "sesh connect \"\$({ sesh list -i; ghq list -p | grep -v -- '-worktrees/' | sed \"s|^\$HOME|~|\"; } | awk '!seen[\$NF]++' | fzf-tmux -p 60%,60% --ansi --no-sort --reverse --border-label ' sesh ')\""
 
       bind h select-pane -L
       bind j select-pane -D

--- a/nix/programs/tmux.nix
+++ b/nix/programs/tmux.nix
@@ -52,6 +52,8 @@
       set -g status-style "bg=default,fg=default"
       set -g window-status-style "bg=default"
       set -g window-status-current-style "bg=default"
+      set -g popup-style "bg=default"
+      set -g popup-border-style "fg=#{@thm_blue}"
 
       set -g status-left-length 120
       set -g status-right-length 200
@@ -80,7 +82,7 @@
       unbind s
       bind S choose-tree -Zs
 
-      bind T run-shell "sesh connect \"\$({ sesh list -i; ghq list -p | grep -v -- '-worktrees/' | sed \"s|^\$HOME|~|\"; } | awk '!seen[\$NF]++' | fzf-tmux -p 60%,60% --ansi --no-sort --reverse --border-label ' sesh ')\""
+      bind T run-shell "sesh connect \"\$({ sesh list -i; ghq list -p | grep -v -- '-worktrees/' | sed \"s|^\$HOME|~|\"; } | awk '!seen[\$NF]++' | fzf-tmux -p 60%,60% --ansi --no-sort --reverse --border-label ' sesh ' --color=bg:-1,bg+:-1,gutter:-1,hl:#cba6f7,hl+:#cba6f7:bold,fg:#cdd6f4,fg+:#cdd6f4:bold,prompt:#89b4fa,pointer:#f38ba8,marker:#a6e3a1,border:#89b4fa,label:#89b4fa)\""
 
       bind h select-pane -L
       bind j select-pane -D


### PR DESCRIPTION
## Why

- tmux のセッション切り替えが `prefix s` の choose-tree しかなく、ghq でクローンした複数リポジトリを横断するのが手間だった
- 既存のキーバインド (`bind s split-window -v`) が tmux デフォルトの `prefix s` (choose-tree) を上書きしていて、意図せずペイン分割になってしまっていた

## What

- `nix/home.nix` の `home.packages` に `zoxide` を追加し、`config/.zshrc` で `eval "$(zoxide init zsh)"` を初期化
- tmux に `prefix T` を追加し、`sesh connect` を fzf-tmux popup で起動。候補は `sesh list -i` (zoxide / tmux 既存セッション) と `ghq list -p` (`-worktrees/` 配下を除外、`~` 形式に正規化、`awk` で末尾フィールドでの dedupe) を統合
- ペイン分割を `prefix -` (横) / `prefix |` (縦) に追加。`bind s` を `unbind` してデフォルトの choose-tree を取り戻し、`prefix S` にズーム付き `choose-tree -Zs` を割り当て