### PR TITLE
feat: tmux ステータスバーに SSID/GIT/日付/バッテリーアイコンを追加する

### DIFF
--- a/nix/programs/tmux.nix
+++ b/nix/programs/tmux.nix
@@ -1,5 +1,28 @@
 { pkgs, ... }:
 
+let
+  ssidScript = pkgs.writeShellScript "tmux-ssid" ''
+    ssid=$(ipconfig getsummary en0 2>/dev/null \
+      | awk -F ' SSID : ' '/ SSID : / {print $2; exit}')
+    [ -z "$ssid" ] && ssid="--"
+    printf '%s' "$ssid" | head -c 18
+  '';
+
+  gitStatusScript = pkgs.writeShellScript "tmux-git-status" ''
+    cd "$1" 2>/dev/null || { printf '%s' "--"; exit; }
+    branch=$(git symbolic-ref --short HEAD 2>/dev/null \
+      || git rev-parse --short HEAD 2>/dev/null)
+    if [ -z "$branch" ]; then
+      printf '%s' "--"
+      exit
+    fi
+    if [ -n "$(git status --porcelain 2>/dev/null)" ]; then
+      printf '%s*' "$branch"
+    else
+      printf '%s' "$branch"
+    fi
+  '';
+in
 {
   programs.tmux = {
     enable = true;
@@ -63,13 +86,12 @@
 
       set -g status-left "#[fg=#{@thm_crust},bg=#{@thm_green}] ◉ #S #[fg=#{@thm_green},bg=default]█ "
 
-      set -g status-right "#[fg=#{@thm_teal},bg=default]█#[fg=#{@thm_crust},bg=#{@thm_teal}] HOST #[fg=#{@thm_fg},bg=#{@thm_surface_0}] #h "
-      set -ag status-right "#[fg=#{@thm_blue},bg=default]█#[fg=#{@thm_crust},bg=#{@thm_blue}] IPv4 #[fg=#{@thm_fg},bg=#{@thm_surface_0}] #(ipconfig getifaddr en0 || echo --) "
-      set -ag status-right "#[fg=#{@thm_sky},bg=default]█#[fg=#{@thm_crust},bg=#{@thm_sky}] SSID #[fg=#{@thm_fg},bg=#{@thm_surface_0}] #(networksetup -getairportnetwork en0 2>/dev/null | sed 's/^.*: //' | head -c 18) "
+      set -g status-right "#[fg=#{@thm_sky},bg=default]█#[fg=#{@thm_crust},bg=#{@thm_sky}] SSID #[fg=#{@thm_fg},bg=#{@thm_surface_0}] #(${ssidScript}) "
       set -ag status-right "#[fg=#{@thm_green},bg=default]█#[fg=#{@thm_crust},bg=#{@thm_green}] LINK #[fg=#{@thm_fg},bg=#{@thm_surface_0}] #{online_status} "
       set -ag status-right "#[fg=#{@thm_yellow},bg=default]█#[fg=#{@thm_crust},bg=#{@thm_yellow}] CPU #[fg=#{@thm_fg},bg=#{@thm_surface_0}] #{cpu_percentage} "
-      set -ag status-right "#[fg=#{@thm_lavender},bg=default]█#[fg=#{@thm_crust},bg=#{@thm_lavender}] PWR #[fg=#{@thm_fg},bg=#{@thm_surface_0}] #{battery_percentage} "
-      set -ag status-right "#[fg=#{@thm_overlay_0},bg=default]█#[fg=#{@thm_fg},bg=#{@thm_overlay_0}] %H:%M "
+      set -ag status-right "#[fg=#{@thm_lavender},bg=default]█#[fg=#{@thm_crust},bg=#{@thm_lavender}] PWR #[fg=#{@thm_fg},bg=#{@thm_surface_0}] #{battery_icon_status} #{battery_percentage} "
+      set -ag status-right "#[fg=#{@thm_mauve},bg=default]█#[fg=#{@thm_crust},bg=#{@thm_mauve}] GIT #[fg=#{@thm_fg},bg=#{@thm_surface_0}] #(${gitStatusScript} '#{pane_current_path}') "
+      set -ag status-right "#[fg=#{@thm_overlay_0},bg=default]█#[fg=#{@thm_fg},bg=#{@thm_overlay_0}] %m/%d (%a) %H:%M "
 
       run-shell ${pkgs.tmuxPlugins.cpu.rtp}
       run-shell ${pkgs.tmuxPlugins.battery.rtp}


### PR DESCRIPTION
## Why

- 既存の tmux ステータスバーの SSID 表示が macOS Sonoma 14.4+ の権限変更で `<redacted>` を返すようになり、Wi-Fi 名がまったく見えない状態だった
- HOST / IPv4 / CLD は普段の作業で参照頻度が低く、逆にバッテリーの充電状態や Git ブランチ、日付の方が画面で常に欲しい情報だったため整理する

## What

- SSID 取得を `networksetup -getairportnetwork` から `ipconfig getsummary en0` 方式に差し替え。Location 権限を WezTerm に付与すれば実 SSID が表示されるようにする (権限がない/未取得時は `--`)
- バッテリー残量に `#{battery_icon_status}` を追加し、充電中かどうかを一目で判別できるようにする
- `pane_current_path` を見て現在のペインの Git ブランチを表示する `GIT` 枠を追加。dirty 時は末尾に `*` を付ける
- 時計フォーマットを `%H:%M` から `%m/%d (%a) %H:%M` に変更
- HOST / IPv4 の枠を削除して右ステータスを整理