### PR TITLE
feat: aqua を Brewfile に追加し PATH を設定する

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -26,6 +26,7 @@ cask "wezterm"
 
 brew "googleworkspace-cli"
 
+brew "aqua"
 brew "libyaml"
 brew "xcodes"
 

--- a/config/.zsh/exports.zsh
+++ b/config/.zsh/exports.zsh
@@ -16,6 +16,9 @@ export PATH="$PATH:$HOME/.local/bin"
 # mise
 eval "$(mise activate zsh)"
 
+# aqua
+export PATH="${AQUA_ROOT_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/aquaproj-aqua}/bin:$PATH"
+
 # go
 export PATH=$PATH:$HOME/gobin
 export GOPATH=$HOME


### PR DESCRIPTION
## Why

- 宣言的 CLI バージョンマネージャ aqua を導入し、CLI ツールのバージョン管理を行えるようにするため

## What

- Brewfile に `brew "aqua"` を追加
- `config/.zsh/exports.zsh` に aqua のインストール先 (`${AQUA_ROOT_DIR:-...aquaproj-aqua}/bin`) を PATH に追加