### PR TITLE
feat: aqua の bin ディレクトリを PATH に追加する

### DIFF
--- a/config/.zsh/exports.zsh
+++ b/config/.zsh/exports.zsh
@@ -73,3 +73,6 @@ export PATH="/opt/homebrew/opt/gnu-sed/libexec/gnubin:$PATH"
 # Android SDK
 export ANDROID_HOME=$HOME/Library/Android/sdk
 export PATH=$PATH:$ANDROID_HOME/platform-tools:$ANDROID_HOME/emulator:$ANDROID_HOME/cmdline-tools/latest/bin
+
+# aqua
+export PATH="${AQUA_ROOT_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/aquaproj-aqua}/bin:$PATH"


### PR DESCRIPTION
## Why

- aqua でインストールしたツールを利用するために、aqua の bin ディレクトリを PATH に通す必要があるため

## What

- `config/.zsh/exports.zsh` に aqua 用の PATH 設定を追記
- `AQUA_ROOT_DIR` 未設定時は `XDG_DATA_HOME`（または `$HOME/.local/share`）配下の `aquaproj-aqua/bin` をフォールバックとして使用