### PR TITLE
feat: redis を nix パッケージに追加する

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -43,6 +43,7 @@
     awscli2
     luarocks
     libpq
+    redis
     ghq
     fvm
     uv


### PR DESCRIPTION
## Why

- ローカルで redis-server を立ち上げたいが、これまで nix で管理していなかった

## What

- nix の `redis` パッケージを `home.packages` に追加（`redis-server` / `redis-cli` 両方が含まれる）
- `redis-server --daemonize yes` → `redis-cli ping` で `PONG` を確認済み