### PR TITLE
feat: notion mcp をリモート設定で追加する

### DIFF
--- a/config/.claude/mcp.json
+++ b/config/.claude/mcp.json
@@ -47,6 +47,10 @@
     "miro": {
       "type": "http",
       "url": "https://mcp.miro.com"
+    },
+    "notion": {
+      "type": "http",
+      "url": "https://mcp.notion.com/mcp"
     }
   }
 }


### PR DESCRIPTION
## 概要

Notion の MCP サーバーをリモート（OAuth）設定で `config/.claude/mcp.json` に追加する。

```json
"notion": {
  "type": "http",
  "url": "https://mcp.notion.com/mcp"
}
```

## 反映手順

1. dotfiles を $HOME にデプロイ
2. Claude Code 内で `/mcp` を実行し Notion の行から OAuth 認証
