### PR TITLE
feat: redis を launchd サービスとして常駐させる

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -18,6 +18,7 @@
     ./programs/yabai.nix
     ./programs/git-worktree-runner.nix
     ./programs/lazygit.nix
+    ./programs/redis.nix
   ];
 
   home.stateVersion = "24.05";

--- a/nix/programs/redis.nix
+++ b/nix/programs/redis.nix
@@ -1,0 +1,34 @@
+{ config, pkgs, lib, ... }:
+
+let
+  dataDir = "${config.home.homeDirectory}/.local/share/redis";
+  logDir = "${config.home.homeDirectory}/.local/state/redis";
+
+  # 開発用キャッシュ用途のため永続化は無効化する。
+  # RDB/AOF を切ることで bgsave 失敗による書き込み停止 (MISCONF) を原理的に防ぐ。
+  # dir も絶対パスで固定し、起動ディレクトリ (cwd) に依存しないようにする。
+  redisConf = pkgs.writeText "redis.conf" ''
+    port 6379
+    bind 127.0.0.1
+    dir ${dataDir}
+    save ""
+    appendonly no
+  '';
+in
+{
+  home.activation.redisDirs = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+    run mkdir -p ${dataDir} ${logDir}
+  '';
+
+  launchd.agents.redis = {
+    enable = true;
+    config = {
+      ProgramArguments = [ "${pkgs.redis}/bin/redis-server" "${redisConf}" ];
+      RunAtLoad = true;
+      KeepAlive = true;
+      WorkingDirectory = dataDir;
+      StandardOutPath = "${logDir}/redis.log";
+      StandardErrorPath = "${logDir}/redis.log";
+    };
+  };
+}


### PR DESCRIPTION
## 概要

redis を launchd エージェントとして常駐起動する `nix/programs/redis.nix` を追加し、`home.nix` から import する。

## 設計

- 開発用キャッシュ用途のため永続化を無効化（`save ""` / `appendonly no`）し、bgsave 失敗による MISCONF 書き込み停止を原理的に防ぐ
- `dir` を絶対パスで固定し、起動ディレクトリに依存しないようにする
- データ/ログディレクトリは activation で事前作成
