### PR TITLE
feat: notion mcp を permission allow に追加する

### DIFF
--- a/config/.claude/settings.json
+++ b/config/.claude/settings.json
@@ -30,7 +30,8 @@
       "mcp__devin__*",
       "mcp__figma__*",
       "mcp__sentry__*",
-      "mcp__miro__*"
+      "mcp__miro__*",
+      "mcp__notion__*"
     ],
     "deny": [
       "Bash(rm -rf *)",


### PR DESCRIPTION
## 概要

Notion MCP のツール (`mcp__notion__*`) を毎回 ask されないよう `config/.claude/settings.json` の permission allow に追加する。

他のリモート MCP（figma/miro/devin 等）と同じ運用に揃える。
