### PR TITLE
feat: denols/python の LSP を宣言的に設定する

### DIFF
--- a/config/.config/nvim/lazyvim.json
+++ b/config/.config/nvim/lazyvim.json
@@ -11,6 +11,7 @@
     "lazyvim.plugins.extras.lang.terraform",
     "lazyvim.plugins.extras.lang.typescript",
     "lazyvim.plugins.extras.lang.markdown",
+    "lazyvim.plugins.extras.lang.python",
     "lazyvim.plugins.extras.lang.yaml",
     "lazyvim.plugins.extras.linting.eslint",
     "lazyvim.plugins.extras.test.core"

--- a/config/.config/nvim/lua/plugins/lsp.lua
+++ b/config/.config/nvim/lua/plugins/lsp.lua
@@ -1,0 +1,27 @@
+return {
+  {
+    "neovim/nvim-lspconfig",
+    opts = function(_, opts)
+      local util = require("lspconfig.util")
+
+      opts.servers = opts.servers or {}
+      opts.servers.denols = {
+        root_dir = util.root_pattern("deno.json", "deno.jsonc"),
+      }
+      opts.servers.vtsls = vim.tbl_deep_extend("force", opts.servers.vtsls or {}, {
+        root_dir = util.root_pattern("package.json", "tsconfig.json"),
+        single_file_support = false,
+      })
+      opts.servers.dbt = {
+        cmd = { "dbt-language-server", "--stdio" },
+        filetypes = { "sql" },
+        root_dir = util.root_pattern("dbt_project.yml"),
+        single_file_support = false,
+      }
+    end,
+  },
+  {
+    "mason-org/mason.nvim",
+    opts = { ensure_installed = { "dbt-language-server" } },
+  },
+}

--- a/config/.config/nvim/lua/plugins/lsp.lua
+++ b/config/.config/nvim/lua/plugins/lsp.lua
@@ -12,16 +12,6 @@ return {
         root_dir = util.root_pattern("package.json", "tsconfig.json"),
         single_file_support = false,
       })
-      opts.servers.dbt = {
-        cmd = { "dbt-language-server", "--stdio" },
-        filetypes = { "sql" },
-        root_dir = util.root_pattern("dbt_project.yml"),
-        single_file_support = false,
-      }
     end,
-  },
-  {
-    "mason-org/mason.nvim",
-    opts = { ensure_installed = { "dbt-language-server" } },
   },
 }

--- a/config/.config/nvim/lua/plugins/lsp.lua
+++ b/config/.config/nvim/lua/plugins/lsp.lua
@@ -2,14 +2,28 @@ return {
   {
     "neovim/nvim-lspconfig",
     opts = function(_, opts)
-      local util = require("lspconfig.util")
+      local deno_markers = { "deno.json", "deno.jsonc" }
+      local node_markers = { "package.json", "tsconfig.json" }
 
       opts.servers = opts.servers or {}
       opts.servers.denols = {
-        root_dir = util.root_pattern("deno.json", "deno.jsonc"),
+        root_dir = function(bufnr, on_dir)
+          local root = vim.fs.root(bufnr, deno_markers)
+          if root then
+            on_dir(root)
+          end
+        end,
       }
       opts.servers.vtsls = vim.tbl_deep_extend("force", opts.servers.vtsls or {}, {
-        root_dir = util.root_pattern("package.json", "tsconfig.json"),
+        root_dir = function(bufnr, on_dir)
+          if vim.fs.root(bufnr, deno_markers) then
+            return
+          end
+          local root = vim.fs.root(bufnr, node_markers)
+          if root then
+            on_dir(root)
+          end
+        end,
         single_file_support = false,
       })
     end,

--- a/config/.config/nvim/lua/plugins/python.lua
+++ b/config/.config/nvim/lua/plugins/python.lua
@@ -1,0 +1,60 @@
+return {
+  {
+    "neovim/nvim-lspconfig",
+    opts = {
+      servers = {
+        pyright = {
+          settings = {
+            python = {
+              analysis = {
+                typeCheckingMode = "off",
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  {
+    "mfussenegger/nvim-lint",
+    opts = {
+      linters_by_ft = {
+        python = { "mypy" },
+      },
+      linters = {
+        mypy = {
+          cmd = function()
+            local venv = os.getenv("VIRTUAL_ENV")
+            if venv then
+              local p = venv .. "/bin/mypy"
+              if vim.fn.executable(p) == 1 then
+                return p
+              end
+            end
+            local root = vim.fs.root(0, { ".venv" })
+            if root then
+              local p = root .. "/.venv/bin/mypy"
+              if vim.fn.executable(p) == 1 then
+                return p
+              end
+            end
+            return "mypy"
+          end,
+          prepend_args = {
+            function()
+              local cfg = vim.fs.find(
+                { "mypy.ini", ".mypy.ini", "pyproject.toml", "setup.cfg" },
+                { upward = true, path = vim.api.nvim_buf_get_name(0) }
+              )[1]
+              return cfg and ("--config-file=" .. cfg) or nil
+            end,
+          },
+        },
+      },
+    },
+  },
+  {
+    "mason-org/mason.nvim",
+    opts = { ensure_installed = { "mypy" } },
+  },
+}


### PR DESCRIPTION
## Why

- LazyVim で deno / python の LSP を使いたいが、Mason UI での手動インストールは dotfiles で再現できないため宣言的に管理したい
- 既存の typescript extra (vtsls) と denols が Deno プロジェクトの `.ts` で両方アタッチし、`deps.ts` 周りのエラーが発生していた

## What

- `lazyvim.json` に `lang.python` extra を追加（basedpyright + ruff）
- `lua/plugins/lsp.lua` を新規追加
  - `denols` は `deno.json`、`vtsls` は `package.json`/`tsconfig.json` を root とし、Deno ↔ vtsls の競合を排他制御
- dbt LSP は当初含めていたが、Mason 非対応（npm 配布）かつ project の Python env に dbt 本体+profiles が必要で導入コストが高いため見送り