### PR TITLE
feat: obsidian の daily notes を claude code から読み書きできるようにする

### DIFF
--- a/config/.claude/CLAUDE.md
+++ b/config/.claude/CLAUDE.md
@@ -19,6 +19,24 @@
 
 - Google Workspace の操作（Gmail、Google Calendar 等）を行う際は、`gws` コマンドを使用する
 
+## Obsidian Daily Notes
+
+- 毎日のタスク管理は Obsidian Vault のデイリーノートで行っている
+- 場所: `~/.obsidian/igsr5/01_dailynotes/`
+- ファイル名は `YYYY-MM-DD.md` 形式
+- フォーマット（既存ノートに合わせる）:
+  ```markdown
+  ---
+  created: YYYY-MM-DDTHH:MM (UTC +09:00)
+  tags: [dailynotes]
+  ---
+
+  ---
+
+  [[YYYY-MM-DD Pomodoro]]
+  ```
+- タスクの読み書きを頼まれたらこのフォルダを直接 Read/Edit/Write する
+
 ## Development Philosophy
 
 ### Before Implementation

--- a/config/.claude/settings.json
+++ b/config/.claude/settings.json
@@ -42,7 +42,8 @@
       "Bash(git checkout -- .)",
       "Bash(git restore .)"
     ],
-    "ask": ["Bash(kube*)"]
+    "ask": ["Bash(kube*)"],
+    "additionalDirectories": ["~/.obsidian/igsr5/01_dailynotes"]
   },
   "extraKnownMarketplaces": {
     "context7": {


### PR DESCRIPTION
## 概要

Obsidian Vault のデイリーノート (`~/.obsidian/igsr5/01_dailynotes/`) を、どのディレクトリで起動した Claude Code からでも読み書きできるようにする。

## 変更内容

- `config/.claude/settings.json`: `permissions.additionalDirectories` に daily notes フォルダを追加（cwd 外へのアクセス許可）
- `config/.claude/CLAUDE.md`: daily notes の場所・ファイル名規則・フォーマットを追記

## 適用方法

`make nix` で反映（`~/.claude/settings.json` は Nix 管理のため）

## スコープ

最小権限として `01_dailynotes` のみ許可。Vault 全体に広げたい場合は `additionalDirectories` にパスを追加する。