### PR TITLE
feat: UserPromptSubmit フックで現在時刻(JST)をコンテキストに注入する

### DIFF
--- a/config/.claude/settings.json
+++ b/config/.claude/settings.json
@@ -77,5 +77,17 @@
   },
   "worktree": {
     "bgIsolation": "worktree"
+  },
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "TZ=Asia/Tokyo date '+[Current time: %Y-%m-%d %H:%M:%S %Z (%A)]'"
+          }
+        ]
+      }
+    ]
   }
 }


### PR DESCRIPTION
## 概要

Claude Code が現在時刻を正確に把握できるように、`UserPromptSubmit` フックでプロンプト送信のたびに現在時刻(JST)をコンテキストへ注入する。

参考: https://zenn.dev/hosaka313/scraps/29cb38277765f9

## 変更内容

- `config/.claude/settings.json` に `hooks.UserPromptSubmit` を追加
- 記事では Python スクリプトを別ファイルに配置しているが、`UserPromptSubmit` は標準出力がそのままコンテキストに注入されるため、`date` コマンド 1 行で実現（管理対象ファイルを増やさない）
- `TZ=Asia/Tokyo` を明示して JST 固定

出力例:
```
[Current time: 2026-07-02 12:56:19 JST (Thursday)]
```

## 適用方法

`make nix` で反映（`~/.claude/settings.json` は Nix 管理のため）。反映後、新しいセッションから有効になる。