### PR TITLE
docs: README の Installation に make secrets と make claude-code を追記する

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ git clone https://github.com/igsr5/dotfiles.git
 cd dotfiles
 make nix          # Install Nix packages and apply Home Manager configuration
 make brew         # Install Homebrew packages from Brewfile
-make secrets      # 1Password 参照から ~/.secrets を生成する
-make claude-code  # Claude Code のプラグインと MCP サーバーをセットアップする
+make secrets      # Generate ~/.secrets from 1Password references
+make claude-code  # Set up Claude Code plugins and MCP servers
 ```
 
 ## Directory Structure

--- a/README.md
+++ b/README.md
@@ -16,8 +16,10 @@ My development environment setup dotfiles
 ```sh
 git clone https://github.com/igsr5/dotfiles.git
 cd dotfiles
-make nix    # Install Nix packages and apply Home Manager configuration
-make brew   # Install Homebrew packages from Brewfile
+make nix          # Install Nix packages and apply Home Manager configuration
+make brew         # Install Homebrew packages from Brewfile
+make secrets      # 1Password 参照から ~/.secrets を生成する
+make claude-code  # Claude Code のプラグインと MCP サーバーをセットアップする
 ```
 
 ## Directory Structure


### PR DESCRIPTION
## 概要

`Makefile` には `make nix` / `make brew` 以外にも `make secrets` と `make claude-code` ターゲットが存在するが、README の Installation セクションには記載されていなかった。既存の記述スタイルに合わせて 2 ターゲットの説明を追記した。

## 変更内容

- `make secrets`: 1Password 参照から `~/.secrets` を生成する
- `make claude-code`: Claude Code のプラグインと MCP サーバーをセットアップする