### PR TITLE
chore: グローバル CLAUDE.md の整理と CircleCI MCP の許可追加

### DIFF
--- a/config/.claude/CLAUDE.md
+++ b/config/.claude/CLAUDE.md
@@ -19,24 +19,6 @@
 
 - Google Workspace の操作（Gmail、Google Calendar 等）を行う際は、`gws` コマンドを使用する
 
-## Obsidian Daily Notes
-
-- 毎日のタスク管理は Obsidian Vault のデイリーノートで行っている
-- 場所: `~/.obsidian/igsr5/01_dailynotes/`
-- ファイル名は `YYYY-MM-DD.md` 形式
-- フォーマット（既存ノートに合わせる）:
-  ```markdown
-  ---
-  created: YYYY-MM-DDTHH:MM (UTC +09:00)
-  tags: [dailynotes]
-  ---
-
-  ---
-
-  [[YYYY-MM-DD Pomodoro]]
-  ```
-- タスクの読み書きを頼まれたらこのフォルダを直接 Read/Edit/Write する
-
 ## Development Philosophy
 
 ### Before Implementation

--- a/config/.claude/settings.json
+++ b/config/.claude/settings.json
@@ -31,7 +31,8 @@
       "mcp__figma__*",
       "mcp__sentry__*",
       "mcp__miro__*",
-      "mcp__notion__*"
+      "mcp__notion__*",
+      "mcp__circleci__*"
     ],
     "deny": [
       "Bash(rm -rf *)",


### PR DESCRIPTION
## 概要

- グローバル CLAUDE.md（`config/.claude/CLAUDE.md`）から "Obsidian Daily Notes" セクションを削除する
- `config/.claude/settings.json` の `permissions.allow` に CircleCI MCP（`mcp__circleci__*`）を追加する

## 理由

- dailynotes に関する記載が毎回のコンテキストに注入されノイズになっていたため
- CircleCI MCP のツールを毎回確認なしで使えるようにするため