### PR TITLE
chore: settings.json から model 設定を削除する

### DIFF
--- a/config/.claude/settings.json
+++ b/config/.claude/settings.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "includeCoAuthoredBy": false,
-  "model": "opus",
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
   },


### PR DESCRIPTION
## Why

- グローバルの `settings.json` に `model` を固定していると、セッションごとにモデルを切り替えたい場合に不都合があるため削除する

## What

- `config/.claude/settings.json` から `"model": "opus"` の設定を削除する