### PR TITLE
feat: Claude Code のステータスラインを 2 行構成に刷新する

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,10 @@ nix:
 brew:
 	brew bundle --file=Brewfile
 
+.PHONY: test
+test:
+	bash config/.claude/statusline_test.sh
+
 CLAUDE_SETTINGS := config/.claude/settings.json
 CLAUDE_MCP := config/.claude/mcp.json
 SECRETS_CONFIG := config/secrets.json

--- a/config/.claude/settings.json
+++ b/config/.claude/settings.json
@@ -73,7 +73,8 @@
   "statusLine": {
     "type": "command",
     "command": "~/.claude/statusline.sh",
-    "padding": 0
+    "padding": 0,
+    "refreshInterval": 10
   },
   "worktree": {
     "bgIsolation": "worktree"

--- a/config/.claude/statusline.sh
+++ b/config/.claude/statusline.sh
@@ -1,9 +1,244 @@
-#!/bin/bash
-# Read JSON input from stdin
+#!/usr/bin/env bash
+# Claude Code の 2 行ステータスライン
+#   1 行目: モデル / effort / ディレクトリ / worktree / git / PR
+#   2 行目: コンテキスト使用率バー / 経過時間 / コスト / 差分行数 / レート制限
+# 端末幅 (COLUMNS) に収まらない場合は優先度の低いセグメントから落とす
+set -u
+
 input=$(cat)
 
-# Extract values using jq
-MODEL_DISPLAY=$(echo "$input" | jq -r '.model.display_name')
-CURRENT_DIR=$(echo "$input" | jq -r '.workspace.current_dir')
+R=$'\033[0m'
+DIM=$'\033[2m'
+BOLD=$'\033[1m'
+CYAN=$'\033[36m'
+BLUE=$'\033[34m'
+GREEN=$'\033[32m'
+YELLOW=$'\033[33m'
+RED=$'\033[31m'
+MAGENTA=$'\033[35m'
 
-echo "[$MODEL_DISPLAY] 📁 ${CURRENT_DIR##*/}"
+COLS=${COLUMNS:-120}
+[ "$COLS" -gt 0 ] 2>/dev/null || COLS=120
+SEP="  "
+
+# 区切りは US(0x1f)。IFS がタブだと空フィールドが畳まれてしまう
+IFS=$'\037' read -r MODEL EFFORT FAST DIR WORKTREE CTX_PCT COST DURATION_MS ADDED REMOVED RL5 RL7 PR_NUM PR_STATE <<<"$(
+  printf '%s' "$input" | jq -r '
+    [
+      (.model.display_name // "?"),
+      (.effort.level // ""),
+      (if .fast_mode then "1" else "" end),
+      (.workspace.current_dir // .cwd // ""),
+      (.workspace.git_worktree // .worktree.name // ""),
+      (.context_window.used_percentage // 0),
+      (.cost.total_cost_usd // ""),
+      (.cost.total_duration_ms // ""),
+      (.cost.total_lines_added // 0),
+      (.cost.total_lines_removed // 0),
+      (.rate_limits.five_hour.used_percentage // ""),
+      (.rate_limits.seven_day.used_percentage // ""),
+      (.pr.number // ""),
+      (.pr.review_state // "")
+    ] | map(tostring) | join("")' 2>/dev/null
+)"
+: "${MODEL:=?}"
+
+# ANSI エスケープを除いた文字列と長さを STRIPPED / VLEN に入れる（fork を避けるため戻り値は使わない）
+strip_ansi() {
+  local s=$1 out=""
+  while [[ $s == *$'\033['* ]]; do
+    out+="${s%%$'\033['*}"
+    s=${s#*$'\033['}
+    s=${s#*m}
+  done
+  STRIPPED="$out$s"
+}
+
+vlen() {
+  strip_ansi "$1"
+  VLEN=${#STRIPPED}
+}
+
+repeat() {
+  local i
+  REP=""
+  for ((i = 0; i < $2; i++)); do REP+="$1"; done
+}
+
+SEG_PRIO=()
+SEG_TEXT=()
+
+seg() {
+  [ -n "$2" ] || return 0
+  SEG_PRIO+=("$1")
+  SEG_TEXT+=("$2")
+}
+
+join_segs() {
+  local i
+  JOINED=""
+  for ((i = 0; i < ${#SEG_TEXT[@]}; i++)); do
+    [ "${SEG_PRIO[$i]}" -gt "$1" ] && continue
+    [ -n "$JOINED" ] && JOINED+="$SEP"
+    JOINED+="${SEG_TEXT[$i]}"
+  done
+}
+
+# 幅に収まる最大の優先度で組み立て、それでも溢れるなら色を捨てて切り詰める
+render() {
+  local p
+  for p in 3 2 1 0; do
+    join_segs "$p"
+    vlen "$JOINED"
+    [ "$VLEN" -le "$COLS" ] && break
+  done
+  if [ "$VLEN" -gt "$COLS" ]; then
+    JOINED="${STRIPPED:0:$((COLS - 1))}…"
+  fi
+  printf '%s\n' "$JOINED"
+  SEG_PRIO=()
+  SEG_TEXT=()
+}
+
+# ホーム配下は ~ に、4 階層以上は中間を … に畳む。幅が狭ければ末尾だけにする
+shorten_dir() {
+  if [ "$COLS" -lt 80 ]; then
+    printf '%s' "${1##*/}"
+    return 0
+  fi
+
+  local p=${1/#$HOME/\~} parts n
+  local IFS=/
+  read -ra parts <<<"$p"
+  n=${#parts[@]}
+  if [ "$n" -gt 3 ]; then
+    printf '%s/%s/…/%s' "${parts[0]}" "${parts[1]}" "${parts[n - 1]}"
+  else
+    printf '%s' "$p"
+  fi
+}
+
+fmt_duration() {
+  local s=$(($1 / 1000))
+  if [ "$s" -lt 60 ]; then
+    printf '%ds' "$s"
+  elif [ "$s" -lt 3600 ]; then
+    printf '%dm' "$((s / 60))"
+  else
+    printf '%dh%02dm' "$((s / 3600))" "$(((s % 3600) / 60))"
+  fi
+}
+
+# git status は重いので 1 秒キャッシュする
+git_segment() {
+  local dir=$1
+  [ -n "$dir" ] && [ -d "$dir" ] || return 0
+  git -C "$dir" rev-parse --is-inside-work-tree >/dev/null 2>&1 || return 0
+
+  # stat は BSD/GNU で書式オプションが非互換なので、時刻はキャッシュの 1 行目に持たせる
+  local key cache now cached_at
+  key=$(printf '%s' "$dir" | cksum | cut -d' ' -f1)
+  cache="${TMPDIR:-/tmp}/claude-statusline-$key"
+  now=$(date +%s)
+  if [ -f "$cache" ]; then
+    IFS= read -r cached_at <"$cache"
+    case ${cached_at:-x} in
+    *[!0-9]*) cached_at=0 ;;
+    esac
+    if [ "$((now - cached_at))" -lt 1 ]; then
+      tail -n +2 "$cache"
+      return 0
+    fi
+  fi
+
+  local branch dirty="" color counts behind ahead out
+  branch=$(git -C "$dir" symbolic-ref --quiet --short HEAD 2>/dev/null) ||
+    branch=$(git -C "$dir" rev-parse --short HEAD 2>/dev/null)
+  [ -n "$branch" ] || return 0
+  [ "${#branch}" -gt 24 ] && branch="${branch:0:23}…"
+
+  if [ -n "$(git -C "$dir" status --porcelain 2>/dev/null | head -1)" ]; then
+    dirty="*"
+    color=$YELLOW
+  else
+    color=$GREEN
+  fi
+
+  out="${color}⎇ ${branch}${dirty}${R}"
+  counts=$(git -C "$dir" rev-list --left-right --count '@{upstream}...HEAD' 2>/dev/null)
+  if [ -n "$counts" ]; then
+    behind=${counts%%[!0-9]*}
+    ahead=${counts##*[!0-9]}
+    [ "${ahead:-0}" -gt 0 ] 2>/dev/null && out+=" ${CYAN}↑${ahead}${R}"
+    [ "${behind:-0}" -gt 0 ] 2>/dev/null && out+=" ${MAGENTA}↓${behind}${R}"
+  fi
+
+  printf '%s\n%s' "$now" "$out" >"$cache"
+  printf '%s' "$out"
+}
+
+context_bar() {
+  local pct=$1 width=20 filled color bar
+  [ "$COLS" -lt 60 ] && width=10
+  filled=$(((pct * width + 50) / 100))
+  [ "$filled" -gt "$width" ] && filled=$width
+  [ "$filled" -lt 0 ] && filled=0
+
+  if [ "$pct" -ge 85 ]; then
+    color=$RED
+  elif [ "$pct" -ge 60 ]; then
+    color=$YELLOW
+  else
+    color=$GREEN
+  fi
+
+  repeat "█" "$filled"
+  bar=$REP
+  repeat "░" "$((width - filled))"
+  printf '%s▕%s%s▏ %d%%%s' "$color" "$bar" "$REP" "$pct" "$R"
+}
+
+# 使用率が高いときだけ出す
+rate_segment() {
+  local label=$1 pct=$2 color=$YELLOW
+  [ -n "$pct" ] || return 0
+  pct=$(printf '%.0f' "$pct" 2>/dev/null) || return 0
+  [ "$pct" -ge 50 ] || return 0
+  [ "$pct" -ge 85 ] && color=$RED
+  printf '%s%s %d%%%s' "$color" "$label" "$pct" "$R"
+}
+
+seg 0 "${BOLD}${CYAN}◆ ${MODEL}${R}"
+[ -n "$FAST" ] && seg 2 "${YELLOW}⚡${R}"
+[ -n "$EFFORT" ] && seg 2 "${DIM}${EFFORT}${R}"
+[ -n "$DIR" ] && seg 1 "${BLUE}$(shorten_dir "$DIR")${R}"
+[ -n "$WORKTREE" ] && seg 3 "${MAGENTA}⑂ ${WORKTREE}${R}"
+seg 1 "$(git_segment "$DIR")"
+
+if [ -n "$PR_NUM" ]; then
+  case "$PR_STATE" in
+  approved) PR_MARK="${GREEN} ✓${R}" ;;
+  changes_requested) PR_MARK="${RED} ✗${R}" ;;
+  pending) PR_MARK="${YELLOW} ●${R}" ;;
+  draft) PR_MARK="${DIM} ◌${R}" ;;
+  *) PR_MARK="" ;;
+  esac
+  seg 3 "${DIM}PR${R} #${PR_NUM}${PR_MARK}"
+fi
+
+render
+
+PCT=$(printf '%.0f' "${CTX_PCT:-0}" 2>/dev/null) || PCT=0
+seg 0 "$(context_bar "$PCT")"
+
+[ -n "$DURATION_MS" ] && seg 1 "${DIM}⏱ $(fmt_duration "${DURATION_MS%%.*}")${R}"
+[ -n "$COST" ] && seg 1 "${DIM}\$$(printf '%.2f' "$COST")${R}"
+
+if [ "${ADDED:-0}" -gt 0 ] 2>/dev/null || [ "${REMOVED:-0}" -gt 0 ] 2>/dev/null; then
+  seg 2 "${GREEN}+${ADDED}${R}${DIM}/${R}${RED}-${REMOVED}${R}"
+fi
+
+seg 2 "$(rate_segment 5h "$RL5")"
+seg 2 "$(rate_segment 7d "$RL7")"
+
+render

--- a/config/.claude/statusline_test.sh
+++ b/config/.claude/statusline_test.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# statusline.sh のテスト。モック JSON を stdin に流して出力を検証する
+set -u
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+STATUSLINE="$SCRIPT_DIR/statusline.sh"
+
+TMPDIR=$(mktemp -d)
+export TMPDIR
+trap 'rm -rf "$TMPDIR"' EXIT
+
+PASS=0
+FAIL=0
+
+strip_ansi() {
+  sed $'s/\x1b\\[[0-9;]*m//g'
+}
+
+# テストごとに git キャッシュを捨てる
+run() {
+  rm -f "$TMPDIR"/claude-statusline-*
+  printf '%s' "$1" | COLUMNS="${2:-200}" bash "$STATUSLINE"
+}
+
+ok() {
+  PASS=$((PASS + 1))
+  printf '  \033[32mok\033[0m   %s\n' "$1"
+}
+
+ng() {
+  FAIL=$((FAIL + 1))
+  printf '  \033[31mFAIL\033[0m %s\n' "$1"
+  [ $# -gt 1 ] && printf '       %s\n' "$2"
+}
+
+assert_contains() {
+  local name=$1 haystack=$2 needle=$3
+  case "$haystack" in
+  *"$needle"*) ok "$name" ;;
+  *) ng "$name" "expected to contain: $needle" ;;
+  esac
+}
+
+assert_not_contains() {
+  local name=$1 haystack=$2 needle=$3
+  case "$haystack" in
+  *"$needle"*) ng "$name" "expected NOT to contain: $needle" ;;
+  *) ok "$name" ;;
+  esac
+}
+
+assert_eq() {
+  local name=$1 actual=$2 expected=$3
+  if [ "$actual" = "$expected" ]; then
+    ok "$name"
+  else
+    ng "$name" "expected [$expected], got [$actual]"
+  fi
+}
+
+FULL_JSON=$(
+  cat <<'JSON'
+{
+  "cwd": "/tmp/not-a-repo",
+  "session_id": "abc123",
+  "version": "2.1.220",
+  "model": { "id": "claude-opus-5", "display_name": "Opus 5" },
+  "workspace": { "current_dir": "/tmp/not-a-repo", "project_dir": "/tmp/not-a-repo" },
+  "effort": { "level": "xhigh" },
+  "fast_mode": false,
+  "context_window": { "used_percentage": 42.3, "context_window_size": 200000 },
+  "cost": {
+    "total_cost_usd": 1.234,
+    "total_duration_ms": 4320000,
+    "total_lines_added": 12,
+    "total_lines_removed": 3
+  },
+  "rate_limits": {
+    "five_hour": { "used_percentage": 18 },
+    "seven_day": { "used_percentage": 4 }
+  },
+  "pr": { "number": 65, "url": "https://github.com/o/r/pull/65", "review_state": "approved" },
+  "output_style": { "name": "default" }
+}
+JSON
+)
+
+# jq でフィールドを差し替えたモックを作る
+mock() {
+  printf '%s' "$FULL_JSON" | jq -c "$1"
+}
+
+echo "statusline.sh"
+
+out=$(run "$FULL_JSON")
+line1=$(printf '%s' "$out" | sed -n 1p | strip_ansi)
+line2=$(printf '%s' "$out" | sed -n 2p | strip_ansi)
+
+assert_eq "2 行で出力する" "$(printf '%s' "$out" | wc -l | tr -d ' ')" "2"
+assert_contains "モデル名を表示する" "$line1" "Opus 5"
+assert_contains "reasoning effort を表示する" "$line1" "xhigh"
+assert_contains "カレントディレクトリ名を表示する" "$line1" "not-a-repo"
+assert_contains "PR 番号を表示する" "$line1" "#65"
+assert_contains "approved な PR を ✓ で示す" "$line1" "✓"
+assert_contains "コンテキスト使用率を表示する" "$line2" "42%"
+assert_contains "コンテキストバーを表示する" "$line2" "█"
+assert_contains "コストを表示する" "$line2" '$1.23'
+assert_contains "経過時間を h/m 形式で表示する" "$line2" "1h12m"
+assert_contains "差分行数を表示する" "$line2" "+12/-3"
+assert_not_contains "null を出力しない" "$out" "null"
+
+out=$(run "$(mock '{cwd: .cwd, model: .model, workspace: .workspace}')")
+assert_eq "最小入力でも 2 行を保つ" "$(printf '%s' "$out" | wc -l | tr -d ' ')" "2"
+assert_not_contains "最小入力で null を出力しない" "$out" "null"
+assert_contains "コンテキスト不明時は 0% とする" "$(printf '%s' "$out" | strip_ansi)" "0%"
+
+out=$(run "$(mock '.pr = null')" | strip_ansi)
+assert_not_contains "PR がなければ PR 欄を出さない" "$out" "#"
+
+out=$(run "$(mock '.rate_limits.five_hour.used_percentage = 18')" | strip_ansi)
+assert_not_contains "レート制限が低いときは表示しない" "$out" "5h"
+
+out=$(run "$(mock '.rate_limits.five_hour.used_percentage = 72')" | strip_ansi)
+assert_contains "5h レート制限が高いときは表示する" "$out" "5h 72%"
+
+out=$(run "$(mock '.rate_limits.seven_day.used_percentage = 88')" | strip_ansi)
+assert_contains "7d レート制限が高いときは表示する" "$out" "7d 88%"
+
+out=$(run "$(mock '.context_window.used_percentage = 92')")
+assert_contains "コンテキスト逼迫時は赤で描画する" "$out" $'\033[31m'
+
+out=$(run "$(mock '.context_window.used_percentage = 10')")
+assert_contains "コンテキストに余裕があれば緑で描画する" "$out" $'\033[32m'
+
+out=$(run "$(mock '.context_window.used_percentage = 70')")
+assert_contains "コンテキスト中程度なら黄で描画する" "$out" $'\033[33m'
+
+out=$(run "$(mock '.fast_mode = true')" | strip_ansi)
+assert_contains "fast mode を ⚡ で示す" "$out" "⚡"
+
+out=$(run "$(mock '.workspace.git_worktree = "wt-feature"')" | strip_ansi)
+assert_contains "worktree 名を表示する" "$out" "wt-feature"
+
+out=$(run "$(mock '.cost.total_duration_ms = 45000')" | strip_ansi)
+assert_contains "1 分未満は秒で表示する" "$out" "45s"
+
+out=$(run "$(mock '.cost.total_duration_ms = 300000')" | strip_ansi)
+assert_contains "1 時間未満は分で表示する" "$out" "5m"
+
+home_json=$(printf '%s' "$FULL_JSON" | jq -c --arg d "$HOME/ghq/github.com/sora-ichigo/dotfiles" '.cwd = $d | .workspace.current_dir = $d')
+out=$(run "$home_json" | strip_ansi)
+assert_contains "ホーム配下は ~ に短縮する" "$out" "~/ghq/"
+assert_contains "深いパスは中間を省略する" "$out" "…/dotfiles"
+
+narrow=$(run "$FULL_JSON" 40)
+too_long=0
+while IFS= read -r line; do
+  plain=$(printf '%s' "$line" | strip_ansi)
+  [ "${#plain}" -gt 40 ] && too_long=1
+done <<<"$narrow"
+assert_eq "COLUMNS に収まるよう切り詰める" "$too_long" "0"
+
+# git リポジトリ内での挙動
+repo="$TMPDIR/repo"
+mkdir -p "$repo"
+git -C "$repo" init --quiet --initial-branch=main
+git -C "$repo" -c user.email=t@t -c user.name=t commit --quiet --allow-empty -m init
+repo_json=$(printf '%s' "$FULL_JSON" | jq -c --arg d "$repo" '.cwd = $d | .workspace.current_dir = $d')
+
+out=$(run "$repo_json" | strip_ansi)
+assert_contains "git ブランチ名を表示する" "$out" "main"
+assert_not_contains "クリーンなリポジトリに dirty マークを付けない" "$out" "main*"
+
+touch "$repo/dirty.txt"
+out=$(run "$repo_json" | strip_ansi)
+assert_contains "変更があれば dirty マークを付ける" "$out" "main*"
+
+echo
+printf 'pass: %d  fail: %d\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/config/.claude/statusline_test.sh
+++ b/config/.claude/statusline_test.sh
@@ -96,7 +96,7 @@ out=$(run "$FULL_JSON")
 line1=$(printf '%s' "$out" | sed -n 1p | strip_ansi)
 line2=$(printf '%s' "$out" | sed -n 2p | strip_ansi)
 
-assert_eq "2 行で出力する" "$(printf '%s' "$out" | wc -l | tr -d ' ')" "2"
+assert_eq "2 行で出力する" "$(printf '%s\n' "$out" | wc -l | tr -d ' ')" "2"
 assert_contains "モデル名を表示する" "$line1" "Opus 5"
 assert_contains "reasoning effort を表示する" "$line1" "xhigh"
 assert_contains "カレントディレクトリ名を表示する" "$line1" "not-a-repo"
@@ -110,7 +110,7 @@ assert_contains "差分行数を表示する" "$line2" "+12/-3"
 assert_not_contains "null を出力しない" "$out" "null"
 
 out=$(run "$(mock '{cwd: .cwd, model: .model, workspace: .workspace}')")
-assert_eq "最小入力でも 2 行を保つ" "$(printf '%s' "$out" | wc -l | tr -d ' ')" "2"
+assert_eq "最小入力でも 2 行を保つ" "$(printf '%s\n' "$out" | wc -l | tr -d ' ')" "2"
 assert_not_contains "最小入力で null を出力しない" "$out" "null"
 assert_contains "コンテキスト不明時は 0% とする" "$(printf '%s' "$out" | strip_ansi)" "0%"
 
@@ -174,6 +174,16 @@ assert_not_contains "クリーンなリポジトリに dirty マークを付け�
 touch "$repo/dirty.txt"
 out=$(run "$repo_json" | strip_ansi)
 assert_contains "変更があれば dirty マークを付ける" "$out" "main*"
+
+out=$(run "$repo_json" 50 | strip_ansi)
+assert_contains "幅が狭くてもディレクトリ名は残す" "$out" "repo"
+assert_contains "幅が狭くても git ブランチは残す" "$out" "main"
+
+# キャッシュを消さずに連続実行し、キャッシュ読み出し経路を検証する
+first=$(run "$repo_json" 2>/dev/null | strip_ansi)
+second=$(printf '%s' "$repo_json" | COLUMNS=200 bash "$STATUSLINE" 2>"$TMPDIR/stderr" | strip_ansi)
+assert_eq "キャッシュ再利用時も同じ出力になる" "$second" "$first"
+assert_eq "キャッシュ再利用時に警告を出さない" "$(cat "$TMPDIR/stderr")" ""
 
 echo
 printf 'pass: %d  fail: %d\n' "$PASS" "$FAIL"


### PR DESCRIPTION
## Why

- ステータスラインがモデル名とディレクトリ名しか表示しておらず、コンテキスト残量・セッションコスト・git の状態といった作業中に最も知りたい情報が見えていなかった
- Claude Code のステータスライン用 JSON には `context_window` / `cost` / `rate_limits` / `pr` / `effort` / `worktree` などが渡ってきており、活用できていなかった

## What

Claude Code のステータスラインを 2 行構成に刷新する。

### 表示内容

- 1 行目: モデル名 / reasoning effort / fast mode / ディレクトリ / worktree 名 / git ブランチ・dirty・ahead/behind / PR 番号とレビュー状態
- 2 行目: コンテキスト使用率バー / 経過時間 / セッションコスト / 差分行数 / レート制限

### 挙動

- コンテキスト使用率はバーの色で段階を示す（〜60% 緑、〜85% 黄、85%〜 赤）
- レート制限は 50% 以上のときのみ表示し、85% 以上で赤にする
- 端末幅 (`COLUMNS`) に収まらない場合は優先度の低いセグメントから順に落とし、狭い幅ではディレクトリを末尾のみ・ブランチ名を切り詰めて表示する
- `git status` は 1 秒キャッシュして、頻繁な再描画による遅延を避ける
- アイドル中も経過時間と git の状態が追従するよう `refreshInterval` を 10 秒に設定する
  - バックグラウンドのサブエージェントが worktree 上で git の状態を変えるため

### テスト

- モック JSON を流して出力を検証する `config/.claude/statusline_test.sh` を追加し、`make test` で実行できるようにする
