### PR TITLE
feat: ステータスラインを端末幅に追従させ、コンテキストのトークン数を表示する

### DIFF
--- a/config/.claude/statusline.sh
+++ b/config/.claude/statusline.sh
@@ -22,7 +22,7 @@ COLS=${COLUMNS:-120}
 SEP="  "
 
 # 区切りは US(0x1f)。IFS がタブだと空フィールドが畳まれてしまう
-IFS=$'\037' read -r MODEL EFFORT FAST DIR WORKTREE CTX_PCT COST DURATION_MS ADDED REMOVED RL5 RL7 PR_NUM PR_STATE <<<"$(
+IFS=$'\037' read -r MODEL EFFORT FAST DIR WORKTREE CTX_PCT CTX_USED CTX_SIZE COST DURATION_MS ADDED REMOVED RL5 RL7 PR_NUM PR_STATE <<<"$(
   printf '%s' "$input" | jq -r '
     [
       (.model.display_name // "?"),
@@ -31,6 +31,10 @@ IFS=$'\037' read -r MODEL EFFORT FAST DIR WORKTREE CTX_PCT COST DURATION_MS ADDE
       (.workspace.current_dir // .cwd // ""),
       (.workspace.git_worktree // .worktree.name // ""),
       (.context_window.used_percentage // 0),
+      (if .context_window.total_input_tokens or .context_window.total_output_tokens
+       then (.context_window.total_input_tokens // 0) + (.context_window.total_output_tokens // 0)
+       else "" end),
+      (.context_window.context_window_size // ""),
       (.cost.total_cost_usd // ""),
       (.cost.total_duration_ms // ""),
       (.cost.total_lines_added // 0),
@@ -100,18 +104,19 @@ render() {
   SEG_TEXT=()
 }
 
-# ホーム配下は ~ に、4 階層以上は中間を … に畳む。幅が狭ければ末尾だけにする
+# レベル 0: ホーム配下を ~ に置き換えただけ / 1: 4 階層以上なら中間を … に畳む / 2: 末尾のみ
 shorten_dir() {
-  if [ "$COLS" -lt 80 ]; then
+  local level=$2 p=${1/#$HOME/\~} parts n
+
+  if [ "$level" -ge 2 ]; then
     printf '%s' "${1##*/}"
     return 0
   fi
 
-  local p=${1/#$HOME/\~} parts n
   local IFS=/
   read -ra parts <<<"$p"
   n=${#parts[@]}
-  if [ "$n" -gt 3 ]; then
+  if [ "$level" -ge 1 ] && [ "$n" -gt 3 ]; then
     printf '%s/%s/…/%s' "${parts[0]}" "${parts[1]}" "${parts[n - 1]}"
   else
     printf '%s' "$p"
@@ -208,13 +213,26 @@ rate_segment() {
   printf '%s%s %d%%%s' "$color" "$label" "$pct" "$R"
 }
 
-seg 0 "${BOLD}${CYAN}◆ ${MODEL}${R}"
-[ -n "$FAST" ] && seg 2 "${YELLOW}⚡${R}"
-[ -n "$EFFORT" ] && seg 2 "${DIM}${EFFORT}${R}"
-[ -n "$DIR" ] && seg 1 "${BLUE}$(shorten_dir "$DIR")${R}"
-[ -n "$WORKTREE" ] && seg 3 "${MAGENTA}⑂ ${WORKTREE}${R}"
-seg 1 "$(git_segment "$DIR")"
+fmt_tokens() {
+  local n=$1
+  if [ "$n" -lt 1000 ]; then
+    printf '%d' "$n"
+  elif [ "$n" -lt 1000000 ]; then
+    if [ "$((n % 1000))" -lt 100 ]; then
+      printf '%dk' "$((n / 1000))"
+    else
+      printf '%d.%dk' "$((n / 1000))" "$(((n % 1000) / 100))"
+    fi
+  elif [ "$((n % 1000000))" -lt 100000 ]; then
+    printf '%dM' "$((n / 1000000))"
+  else
+    printf '%d.%dM' "$((n / 1000000))" "$(((n % 1000000) / 100000))"
+  fi
+}
 
+GIT_SEG=$(git_segment "$DIR")
+
+PR_SEG=""
 if [ -n "$PR_NUM" ]; then
   case "$PR_STATE" in
   approved) PR_MARK="${GREEN} ✓${R}" ;;
@@ -223,13 +241,46 @@ if [ -n "$PR_NUM" ]; then
   draft) PR_MARK="${DIM} ◌${R}" ;;
   *) PR_MARK="" ;;
   esac
-  seg 3 "${DIM}PR${R} #${PR_NUM}${PR_MARK}"
+  PR_SEG="${DIM}PR${R} #${PR_NUM}${PR_MARK}"
 fi
 
-render
+build_line1() {
+  SEG_PRIO=()
+  SEG_TEXT=()
+  seg 0 "${BOLD}${CYAN}◆ ${MODEL}${R}"
+  [ -n "$FAST" ] && seg 2 "${YELLOW}⚡${R}"
+  [ -n "$EFFORT" ] && seg 2 "${DIM}${EFFORT}${R}"
+  [ -n "$DIR" ] && seg 0 "${BLUE}$(shorten_dir "$DIR" "$1")${R}"
+  [ -n "$WORKTREE" ] && seg 3 "${MAGENTA}⑂ ${WORKTREE}${R}"
+  seg 1 "$GIT_SEG"
+  seg 3 "$PR_SEG"
+}
+
+# セグメントを落とすより先にパスを縮めて、余った幅を使い切る
+LINE1=""
+for p in 3 2 1 0; do
+  for d in 0 1 2; do
+    build_line1 "$d"
+    join_segs "$p"
+    vlen "$JOINED"
+    if [ "$VLEN" -le "$COLS" ]; then
+      LINE1=$JOINED
+      break 2
+    fi
+  done
+done
+[ -n "$LINE1" ] || LINE1="${STRIPPED:0:$((COLS - 1))}…"
+printf '%s\n' "$LINE1"
+
+SEG_PRIO=()
+SEG_TEXT=()
 
 PCT=$(printf '%.0f' "${CTX_PCT:-0}" 2>/dev/null) || PCT=0
 seg 0 "$(context_bar "$PCT")"
+
+if [ -n "$CTX_USED" ] && [ -n "$CTX_SIZE" ]; then
+  seg 1 "${DIM}$(fmt_tokens "${CTX_USED%%.*}")/$(fmt_tokens "${CTX_SIZE%%.*}")${R}"
+fi
 
 [ -n "$DURATION_MS" ] && seg 1 "${DIM}⏱ $(fmt_duration "${DURATION_MS%%.*}")${R}"
 [ -n "$COST" ] && seg 1 "${DIM}\$$(printf '%.2f' "$COST")${R}"

--- a/config/.claude/statusline_test.sh
+++ b/config/.claude/statusline_test.sh
@@ -68,7 +68,12 @@ FULL_JSON=$(
   "workspace": { "current_dir": "/tmp/not-a-repo", "project_dir": "/tmp/not-a-repo" },
   "effort": { "level": "xhigh" },
   "fast_mode": false,
-  "context_window": { "used_percentage": 42.3, "context_window_size": 200000 },
+  "context_window": {
+    "used_percentage": 42.3,
+    "context_window_size": 200000,
+    "total_input_tokens": 80000,
+    "total_output_tokens": 4200
+  },
   "cost": {
     "total_cost_usd": 1.234,
     "total_duration_ms": 4320000,
@@ -107,7 +112,18 @@ assert_contains "コンテキストバーを表示する" "$line2" "█"
 assert_contains "コストを表示する" "$line2" '$1.23'
 assert_contains "経過時間を h/m 形式で表示する" "$line2" "1h12m"
 assert_contains "差分行数を表示する" "$line2" "+12/-3"
+assert_contains "トークン数を実数で表示する" "$line2" "84.2k/200k"
 assert_not_contains "null を出力しない" "$out" "null"
+
+out=$(run "$(mock '.context_window.context_window_size = 1000000')" | strip_ansi)
+assert_contains "100 万トークンは M 表記にする" "$out" "/1M"
+
+out=$(run "$(mock '.context_window.total_output_tokens = 0 | .context_window.total_input_tokens = 512')" | strip_ansi)
+assert_contains "1000 未満はそのまま表示する" "$out" "512/200k"
+
+out=$(run "$(mock '.context_window = {used_percentage: 42.3}')" | strip_ansi)
+assert_not_contains "トークン数が不明なら出さない" "$out" "/200k"
+assert_contains "トークン数が不明でも使用率は出す" "$out" "42%"
 
 out=$(run "$(mock '{cwd: .cwd, model: .model, workspace: .workspace}')")
 assert_eq "最小入力でも 2 行を保つ" "$(printf '%s\n' "$out" | wc -l | tr -d ' ')" "2"
@@ -148,9 +164,17 @@ out=$(run "$(mock '.cost.total_duration_ms = 300000')" | strip_ansi)
 assert_contains "1 時間未満は分で表示する" "$out" "5m"
 
 home_json=$(printf '%s' "$FULL_JSON" | jq -c --arg d "$HOME/ghq/github.com/sora-ichigo/dotfiles" '.cwd = $d | .workspace.current_dir = $d')
-out=$(run "$home_json" | strip_ansi)
+out=$(run "$home_json" 200 | strip_ansi)
 assert_contains "ホーム配下は ~ に短縮する" "$out" "~/ghq/"
-assert_contains "深いパスは中間を省略する" "$out" "…/dotfiles"
+assert_contains "幅に余裕があればパスを畳まない" "$out" "~/ghq/github.com/sora-ichigo/dotfiles"
+
+out=$(run "$home_json" 78 | strip_ansi)
+assert_contains "幅が足りなければ中間を省略する" "$out" "…/dotfiles"
+assert_not_contains "中間省略時はフルパスを出さない" "$out" "github.com"
+
+out=$(run "$home_json" 46 | strip_ansi)
+assert_contains "さらに狭ければ末尾のみにする" "$out" "dotfiles"
+assert_not_contains "末尾のみのときは ~ を出さない" "$out" "~/"
 
 narrow=$(run "$FULL_JSON" 40)
 too_long=0

--- a/config/.claude/statusline_test.sh
+++ b/config/.claude/statusline_test.sh
@@ -163,17 +163,18 @@ assert_contains "1 分未満は秒で表示する" "$out" "45s"
 out=$(run "$(mock '.cost.total_duration_ms = 300000')" | strip_ansi)
 assert_contains "1 時間未満は分で表示する" "$out" "5m"
 
-home_json=$(printf '%s' "$FULL_JSON" | jq -c --arg d "$HOME/ghq/github.com/sora-ichigo/dotfiles" '.cwd = $d | .workspace.current_dir = $d')
+# git 状態に左右されないよう、存在しないパスを使う
+home_json=$(printf '%s' "$FULL_JSON" | jq -c --arg d "$HOME/ghq/github.com/example/no-such-repo" '.cwd = $d | .workspace.current_dir = $d')
 out=$(run "$home_json" 200 | strip_ansi)
 assert_contains "ホーム配下は ~ に短縮する" "$out" "~/ghq/"
-assert_contains "幅に余裕があればパスを畳まない" "$out" "~/ghq/github.com/sora-ichigo/dotfiles"
+assert_contains "幅に余裕があればパスを畳まない" "$out" "~/ghq/github.com/example/no-such-repo"
 
-out=$(run "$home_json" 78 | strip_ansi)
-assert_contains "幅が足りなければ中間を省略する" "$out" "…/dotfiles"
+out=$(run "$home_json" 55 | strip_ansi)
+assert_contains "幅が足りなければ中間を省略する" "$out" "…/no-such-repo"
 assert_not_contains "中間省略時はフルパスを出さない" "$out" "github.com"
 
-out=$(run "$home_json" 46 | strip_ansi)
-assert_contains "さらに狭ければ末尾のみにする" "$out" "dotfiles"
+out=$(run "$home_json" 40 | strip_ansi)
+assert_contains "さらに狭ければ末尾のみにする" "$out" "no-such-repo"
 assert_not_contains "末尾のみのときは ~ を出さない" "$out" "~/"
 
 narrow=$(run "$FULL_JSON" 40)


### PR DESCRIPTION
## Why

- 端末の横幅に余裕があるときでもディレクトリパスが常に `~/ghq/…/dotfiles` の形に畳まれてしまい、空いている幅を活かせていなかった
- コンテキスト使用率が割合でしか分からず、実際に何トークン消費しているかが把握できなかった

- https://github.com/sora-ichigo/dotfiles/pull/66

## What

ステータスラインを端末幅に追従させ、コンテキストの実トークン数を表示する。

### 幅に応じたパスの段階的な短縮

- ディレクトリ表示を「フルパス → 中間を … に省略 → 末尾のみ」の 3 段階にし、幅に収まる最長のものを選ぶ
- セグメントを落とすより先にパスを縮めることで、情報量を保ったまま幅に収める
- ディレクトリは最優先セグメントとし、幅が狭いときも表示を維持する

### コンテキストのトークン数表示

- 使用率バーの隣に `122.2k/1M` の形式で実トークン数と上限を表示する
- 1000 未満はそのまま、1000 以上は k、100 万以上は M で表記し、端数がなければ小数を省く
