### PR TITLE
chore: Claude Code のデフォルトモデルを sonnet にする

### DIFF
--- a/config/.claude/settings.json
+++ b/config/.claude/settings.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "includeCoAuthoredBy": false,
+  "model": "sonnet",
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
   },


### PR DESCRIPTION
`config/.claude/settings.json` に `"model": "sonnet"` を追加。

plan mode だけ別モデルにする設定は Claude Code に存在しない（`opusplan` alias 以外の組み合わせは不可、`planModeModel` のような設定キー・環境変数もなし）ため、plan したいときは `/model fable` で手動切替する運用にする。