### PR TITLE
feat: Claude Code のデフォルトパーミッションモードを auto にする

### DIFF
--- a/config/.claude/settings.json
+++ b/config/.claude/settings.json
@@ -6,6 +6,7 @@
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
   },
   "permissions": {
+    "defaultMode": "auto",
     "allow": [
       "Read",
       "Edit",


### PR DESCRIPTION
## Summary
- `config/.claude/settings.json` に `permissions.defaultMode: "auto"` を追加し、Claude Code のデフォルトパーミッションモードを auto（バックグラウンド安全チェック付き自動承認）に変更

## Test plan
- [ ] `make nix` を実行して Home Manager 経由で `~/.claude/settings.json` に反映されることを確認
- [ ] Claude Code を再起動し、モードが auto になっていることを確認