### PR TITLE
fix: lazygit の pager 設定を diffRenderers スキーマに移行する

### DIFF
--- a/config/lazygit/config.yml
+++ b/config/lazygit/config.yml
@@ -1,5 +1,3 @@
 git:
-  pagers:
-    - colorArg: always
-      pager: delta --paging=never
-      useConfig: false
+  diffRenderers:
+    - command: delta --paging=never


### PR DESCRIPTION
## Summary
- lazygit のバージョンアップで `git.pagers` が `git.diffRenderers` にリネームされた
- 旧スキーマの設定ファイルを読み込むと lazygit が実行時に自動マイグレーションを試みるが、home-manager が symlink する Nix store（読み取り専用）へは書き戻せず `permission denied` で失敗していた
- `config/lazygit/config.yml` を新スキーマ（`diffRenderers` / `command`）に更新し、実行時マイグレーションを不要にした

## Test plan
- [x] `./install.sh` で home-manager 設定を適用
- [x] `lazygit` 起動時に migration メッセージ・permission denied エラーが出ないことを確認