### PR TITLE
chore: Renovate の nix flake.lock 定期更新を有効化する

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,9 @@
     "config:recommended"
   ],
   "nix": {
-    "enabled": true
+    "enabled": true,
+    "lockFileMaintenance": {
+      "enabled": true
+    }
   }
 }


### PR DESCRIPTION
## Summary
- `nix/flake.lock` の `nixpkgs`（`nixpkgs-unstable`）や `home-manager` はブランチ追従の入力で、明確な新バージョンタグが付かないため、Renovate の通常のバージョン検出では更新PRが作られない
- `nix.lockFileMaintenance.enabled` を追加し、定期的な lockFileMaintenance でlock全体を最新化させる

## Test plan
- [ ] Renovate の次回実行後、Dependency Dashboard に flake.lock 更新PRが出現するか確認