### PR TITLE
feat: herdr を追加し tmux 相当のキーバインドを設定する

### DIFF
--- a/config/.config/herdr/config.toml
+++ b/config/.config/herdr/config.toml
@@ -1,9 +1,6 @@
 [keys]
 navigate_workspace_up = ["up", "k"]
 navigate_workspace_down = ["down", "j"]
-next_agent = "prefix+shift+j"
-previous_agent = "prefix+shift+k"
-focus_agent = "prefix+alt+1..9"
 
 [[keys.command]]
 key = "prefix+t"

--- a/config/.config/herdr/config.toml
+++ b/config/.config/herdr/config.toml
@@ -1,0 +1,16 @@
+[keys]
+prefix = "ctrl+t"
+
+[[keys.command]]
+key = "prefix+t"
+type = "popup"
+command = "sesh connect \"$({ sesh list -i; ghq list -p | grep -v -- '-worktrees/' | sed \"s|^$HOME|~|\"; } | awk '!seen[$NF]++' | fzf --ansi --no-sort --reverse --border-label ' sesh ' --color=bg:-1,bg+:-1,gutter:-1,hl:#cba6f7,hl+:#cba6f7:bold,fg:#cdd6f4,fg+:#cdd6f4:bold,prompt:#89b4fa,pointer:#f38ba8,marker:#a6e3a1,border:#89b4fa,label:#89b4fa)\""
+description = "sesh"
+width = "60%"
+height = "60%"
+
+[ui]
+mouse_capture = true
+
+[theme]
+name = "catppuccin"

--- a/config/.config/herdr/config.toml
+++ b/config/.config/herdr/config.toml
@@ -1,3 +1,7 @@
+[keys]
+navigate_workspace_up = ["up", "k"]
+navigate_workspace_down = ["down", "j"]
+
 [[keys.command]]
 key = "prefix+t"
 type = "popup"

--- a/config/.config/herdr/config.toml
+++ b/config/.config/herdr/config.toml
@@ -1,6 +1,3 @@
-[keys]
-prefix = "ctrl+t"
-
 [[keys.command]]
 key = "prefix+t"
 type = "popup"

--- a/config/.config/herdr/config.toml
+++ b/config/.config/herdr/config.toml
@@ -1,6 +1,9 @@
 [keys]
 navigate_workspace_up = ["up", "k"]
 navigate_workspace_down = ["down", "j"]
+next_agent = "prefix+shift+j"
+previous_agent = "prefix+shift+k"
+focus_agent = "prefix+alt+1..9"
 
 [[keys.command]]
 key = "prefix+t"

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -7,6 +7,7 @@
     ./programs/gh.nix
     ./programs/starship.nix
     ./programs/tmux.nix
+    ./programs/herdr.nix
     ./programs/neovim.nix
     ./programs/zsh.nix
     ./programs/mise.nix

--- a/nix/programs/herdr.nix
+++ b/nix/programs/herdr.nix
@@ -1,0 +1,5 @@
+{ pkgs, ... }:
+
+{
+  home.packages = [ pkgs.herdr ];
+}

--- a/nix/programs/herdr.nix
+++ b/nix/programs/herdr.nix
@@ -2,4 +2,6 @@
 
 {
   home.packages = [ pkgs.herdr ];
+
+  home.file.".config/herdr/config.toml".source = ../../config/.config/herdr/config.toml;
 }


### PR DESCRIPTION
## Summary
- herdr をデフォルト設定で追加(tmuxは併存)
- ワークスペース切り替えを j/k でも操作できるように設定
- sesh 連携のカスタムコマンド、マウス有効化、catppuccinテーマを設定

## Test plan
- [x] `herdr config check` で `config: ok` を確認
- [x] `./install.sh` で実機に適用し `herdr` コマンドが利用できることを確認