### PR TITLE
tmux プラグイン管理を TPM 方式に切り替え、tmux-agent-sidebar を導入

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ secrets:
 #       mcp.json の設定を変更した場合は、先に `claude mcp remove <name>` で削除してから再実行すること
 .PHONY: claude-code
 claude-code:
-	@jq -r '.extraKnownMarketplaces | to_entries[] | .value.source.repo' $(CLAUDE_SETTINGS) | while read repo; do \
+	@jq -r '.extraKnownMarketplaces | to_entries[] | .value.source | (.repo // .path)' $(CLAUDE_SETTINGS) | while read repo; do \
 		claude plugin marketplace add "$$repo" 2>/dev/null || true; \
 	done
 	@jq -r '.enabledPlugins | to_entries[] | select(.value == true) | .key' $(CLAUDE_SETTINGS) | while read plugin; do \

--- a/config/.claude/settings.json
+++ b/config/.claude/settings.json
@@ -65,12 +65,19 @@
         "source": "github",
         "repo": "anthropics/claude-plugins-official"
       }
+    },
+    "tmux-agent-sidebar": {
+      "source": {
+        "source": "directory",
+        "path": "~/.tmux/plugins/tmux-agent-sidebar"
+      }
     }
   },
   "enabledPlugins": {
     "context7-plugin@context7-marketplace": true,
     "marp-wantedly@wantedly-cc-plugins": true,
-    "slack@claude-plugins-official": true
+    "slack@claude-plugins-official": true,
+    "tmux-agent-sidebar@hiroppy": true
   },
   "statusLine": {
     "type": "command",

--- a/config/.config/tmux/scripts/tmux-git-status.sh
+++ b/config/.config/tmux/scripts/tmux-git-status.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+cd "$1" 2>/dev/null || { printf '%s' "--"; exit; }
+branch=$(git symbolic-ref --short HEAD 2>/dev/null \
+  || git rev-parse --short HEAD 2>/dev/null)
+if [ -z "$branch" ]; then
+  printf '%s' "--"
+  exit
+fi
+if [ -n "$(git status --porcelain 2>/dev/null)" ]; then
+  printf '%s*' "$branch"
+else
+  printf '%s' "$branch"
+fi

--- a/config/.config/tmux/scripts/tmux-ssid.sh
+++ b/config/.config/tmux/scripts/tmux-ssid.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+ssid=$(ipconfig getsummary en0 2>/dev/null \
+  | awk -F ' SSID : ' '/ SSID : / {print $2; exit}')
+[ -z "$ssid" ] && ssid="--"
+printf '%s' "$ssid" | head -c 18

--- a/config/.config/tmux/tmux.conf
+++ b/config/.config/tmux/tmux.conf
@@ -1,0 +1,108 @@
+set -g default-terminal "screen-256color"
+set -g base-index 0
+setw -g pane-base-index 0
+
+set -g status-keys vi
+set -g mode-keys vi
+
+unbind C-b
+set -g prefix C-t
+bind -N "Send the prefix key through to the application" C-t send-prefix
+
+set -g mouse on
+set -g focus-events off
+setw -g aggressive-resize off
+setw -g clock-mode-style 12
+set -s escape-time 10
+set -g history-limit 2000
+
+# ============================================= #
+# Plugins (managed by TPM)                      #
+# ============================================= #
+
+set -g @plugin 'tmux-plugins/tpm'
+set -g @plugin 'tmux-plugins/tmux-sensible'
+set -g @plugin 'tmux-plugins/tmux-yank'
+set -g @plugin 'catppuccin/tmux'
+set -g @plugin 'tmux-plugins/tmux-resurrect'
+set -g @plugin 'tmux-plugins/tmux-continuum'
+set -g @plugin 'tmux-plugins/tmux-cpu'
+set -g @plugin 'tmux-plugins/tmux-battery'
+set -g @plugin 'tmux-plugins/tmux-online-status'
+set -g @plugin 'hiroppy/tmux-agent-sidebar'
+
+set -g @catppuccin_flavor "mocha"
+set -g @catppuccin_window_status_style "rounded"
+set -g @catppuccin_window_default_text " #W"
+set -g @catppuccin_window_current_text " #W"
+set -g @catppuccin_status_background "default"
+set -g @catppuccin_status_left_separator  "█"
+set -g @catppuccin_status_right_separator "█"
+set -g @catppuccin_status_fill "icon"
+set -g @catppuccin_status_connect_separator "no"
+
+set -g @resurrect-strategy-nvim "session"
+set -g @resurrect-capture-pane-contents "on"
+
+set -g @continuum-restore "on"
+set -g @continuum-save-interval "15"
+
+# ============================================= #
+
+set -ag terminal-overrides ",xterm-256color:RGB"
+
+set -g status-position "top"
+set -g status-justify "left"
+set -g status-interval 2
+
+set -g pane-active-border-style fg=colour66
+set -g status-style "bg=default,fg=default"
+set -g window-status-style "bg=default"
+set -g window-status-current-style "bg=default"
+set -g popup-style "bg=default"
+set -g popup-border-style "fg=#{@thm_blue}"
+
+set -g status-left-length 120
+set -g status-right-length 200
+
+set -g @online_icon "▲ UP"
+set -g @offline_icon "▽ DN"
+
+set -g status-left "#[fg=#{@thm_crust},bg=#{@thm_green}] ◉ #S #[fg=#{@thm_green},bg=default]█ "
+
+set -g status-right "#[fg=#{@thm_sky},bg=default]█#[fg=#{@thm_crust},bg=#{@thm_sky}] SSID #[fg=#{@thm_fg},bg=#{@thm_surface_0}] #(~/.config/tmux/scripts/tmux-ssid.sh) "
+set -ag status-right "#[fg=#{@thm_green},bg=default]█#[fg=#{@thm_crust},bg=#{@thm_green}] LINK #[fg=#{@thm_fg},bg=#{@thm_surface_0}] #{online_status} "
+set -ag status-right "#[fg=#{@thm_yellow},bg=default]█#[fg=#{@thm_crust},bg=#{@thm_yellow}] CPU #[fg=#{@thm_fg},bg=#{@thm_surface_0}] #{cpu_percentage} "
+set -ag status-right "#[fg=#{@thm_lavender},bg=default]█#[fg=#{@thm_crust},bg=#{@thm_lavender}] PWR #[fg=#{@thm_fg},bg=#{@thm_surface_0}] #{battery_icon_status} #{battery_percentage} "
+set -ag status-right "#[fg=#{@thm_mauve},bg=default]█#[fg=#{@thm_crust},bg=#{@thm_mauve}] GIT #[fg=#{@thm_fg},bg=#{@thm_surface_0}] #(~/.config/tmux/scripts/tmux-git-status.sh '#{pane_current_path}') "
+set -ag status-right "#[fg=#{@thm_overlay_0},bg=default]█#[fg=#{@thm_fg},bg=#{@thm_overlay_0}] %m/%d (%a) %H:%M "
+
+bind v split-window -h -c "#{pane_current_path}"
+bind "|" split-window -h -c "#{pane_current_path}"
+bind "-" split-window -v -c "#{pane_current_path}"
+
+unbind s
+bind S choose-tree -Zs
+
+bind T run-shell "sesh connect \"\$({ sesh list -i; ghq list -p | grep -v -- '-worktrees/' | sed \"s|^\$HOME|~|\"; } | awk '!seen[\$NF]++' | fzf-tmux -p 60%,60% --ansi --no-sort --reverse --border-label ' sesh ' --color=bg:-1,bg+:-1,gutter:-1,hl:#cba6f7,hl+:#cba6f7:bold,fg:#cdd6f4,fg+:#cdd6f4:bold,prompt:#89b4fa,pointer:#f38ba8,marker:#a6e3a1,border:#89b4fa,label:#89b4fa)\""
+
+bind h select-pane -L
+bind j select-pane -D
+bind k select-pane -U
+bind l select-pane -R
+
+bind -r H resize-pane -L 5
+bind -r J resize-pane -D 5
+bind -r K resize-pane -U 5
+bind -r L resize-pane -R 5
+
+bind -T copy-mode-vi v send -X begin-selection
+bind -T copy-mode-vi V send -X select-line
+bind -T copy-mode-vi C-v send -X rectangle-toggle
+bind -T copy-mode-vi y send -X copy-pipe-and-cancel "pbcopy"
+bind -T copy-mode-vi Y send -X copy-line
+bind -T copy-mode-vi Enter send -X copy-pipe-and-cancel "pbcopy"
+bind -T copy-mode-vi MouseDragEnd1Pane send -X copy-pipe-and-cancel "pbcopy"
+bind-key C-p paste-buffer
+
+run '~/.tmux/plugins/tpm/tpm'

--- a/nix/programs/claude-code.nix
+++ b/nix/programs/claude-code.nix
@@ -1,8 +1,16 @@
-{ ... }:
+{ pkgs, lib, ... }:
 
 {
   home.file.".claude/CLAUDE.md".source = ../../config/.claude/CLAUDE.md;
-  home.file.".claude/settings.json".source = ../../config/.claude/settings.json;
   home.file.".claude/statusline.sh".source = ../../config/.claude/statusline.sh;
   home.file.".claude/skills".source = ../../config/.claude/skills;
+
+  # settings.json は `claude plugin install` 等が実行時に書き込むため、
+  # symlink ではなく初回のみコピーする書き込み可能ファイルとして配置する。
+  # dotfiles 側の変更を反映するには ~/.claude/settings.json を削除してから make nix を再実行する。
+  home.activation.claudeSettings = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+    if [ ! -e "$HOME/.claude/settings.json" ]; then
+      run install -m644 ${../../config/.claude/settings.json} "$HOME/.claude/settings.json"
+    fi
+  '';
 }

--- a/nix/programs/tmux.nix
+++ b/nix/programs/tmux.nix
@@ -1,131 +1,14 @@
-{ pkgs, ... }:
+{ pkgs, lib, ... }:
 
-let
-  ssidScript = pkgs.writeShellScript "tmux-ssid" ''
-    ssid=$(ipconfig getsummary en0 2>/dev/null \
-      | awk -F ' SSID : ' '/ SSID : / {print $2; exit}')
-    [ -z "$ssid" ] && ssid="--"
-    printf '%s' "$ssid" | head -c 18
-  '';
-
-  gitStatusScript = pkgs.writeShellScript "tmux-git-status" ''
-    cd "$1" 2>/dev/null || { printf '%s' "--"; exit; }
-    branch=$(git symbolic-ref --short HEAD 2>/dev/null \
-      || git rev-parse --short HEAD 2>/dev/null)
-    if [ -z "$branch" ]; then
-      printf '%s' "--"
-      exit
-    fi
-    if [ -n "$(git status --porcelain 2>/dev/null)" ]; then
-      printf '%s*' "$branch"
-    else
-      printf '%s' "$branch"
-    fi
-  '';
-in
 {
-  programs.tmux = {
-    enable = true;
-    prefix = "C-t";
-    keyMode = "vi";
-    mouse = true;
-    terminal = "screen-256color";
+  home.file.".config/tmux/tmux.conf".source = ../../config/.config/tmux/tmux.conf;
+  home.file.".config/tmux/scripts".source = ../../config/.config/tmux/scripts;
 
-    plugins = with pkgs.tmuxPlugins; [
-      sensible
-      yank
-      {
-        plugin = catppuccin;
-        extraConfig = ''
-          set -g @catppuccin_flavor "mocha"
-          set -g @catppuccin_window_status_style "rounded"
-          set -g @catppuccin_window_default_text " #W"
-          set -g @catppuccin_window_current_text " #W"
-          set -g @catppuccin_status_background "default"
-          set -g @catppuccin_status_left_separator  "█"
-          set -g @catppuccin_status_right_separator "█"
-          set -g @catppuccin_status_fill "icon"
-          set -g @catppuccin_status_connect_separator "no"
-        '';
-      }
-      {
-        plugin = resurrect;
-        extraConfig = ''
-          set -g @resurrect-strategy-nvim "session"
-          set -g @resurrect-capture-pane-contents "on"
-        '';
-      }
-      {
-        plugin = continuum;
-        extraConfig = ''
-          set -g @continuum-restore "on"
-          set -g @continuum-save-interval "15"
-        '';
-      }
-    ];
+  home.activation.installTPM = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+    if [ ! -d "$HOME/.tmux/plugins/tpm" ]; then
+      run ${pkgs.git}/bin/git clone https://github.com/tmux-plugins/tpm "$HOME/.tmux/plugins/tpm"
+    fi
+  '';
 
-    extraConfig = ''
-      set -ag terminal-overrides ",xterm-256color:RGB"
-
-      set -g status-position "top"
-      set -g status-justify "left"
-      set -g status-interval 2
-
-      set -g pane-active-border-style fg=colour66
-      set -g status-style "bg=default,fg=default"
-      set -g window-status-style "bg=default"
-      set -g window-status-current-style "bg=default"
-      set -g popup-style "bg=default"
-      set -g popup-border-style "fg=#{@thm_blue}"
-
-      set -g status-left-length 120
-      set -g status-right-length 200
-
-      set -g @online_icon "▲ UP"
-      set -g @offline_icon "▽ DN"
-
-      set -g status-left "#[fg=#{@thm_crust},bg=#{@thm_green}] ◉ #S #[fg=#{@thm_green},bg=default]█ "
-
-      set -g status-right "#[fg=#{@thm_sky},bg=default]█#[fg=#{@thm_crust},bg=#{@thm_sky}] SSID #[fg=#{@thm_fg},bg=#{@thm_surface_0}] #(${ssidScript}) "
-      set -ag status-right "#[fg=#{@thm_green},bg=default]█#[fg=#{@thm_crust},bg=#{@thm_green}] LINK #[fg=#{@thm_fg},bg=#{@thm_surface_0}] #{online_status} "
-      set -ag status-right "#[fg=#{@thm_yellow},bg=default]█#[fg=#{@thm_crust},bg=#{@thm_yellow}] CPU #[fg=#{@thm_fg},bg=#{@thm_surface_0}] #{cpu_percentage} "
-      set -ag status-right "#[fg=#{@thm_lavender},bg=default]█#[fg=#{@thm_crust},bg=#{@thm_lavender}] PWR #[fg=#{@thm_fg},bg=#{@thm_surface_0}] #{battery_icon_status} #{battery_percentage} "
-      set -ag status-right "#[fg=#{@thm_mauve},bg=default]█#[fg=#{@thm_crust},bg=#{@thm_mauve}] GIT #[fg=#{@thm_fg},bg=#{@thm_surface_0}] #(${gitStatusScript} '#{pane_current_path}') "
-      set -ag status-right "#[fg=#{@thm_overlay_0},bg=default]█#[fg=#{@thm_fg},bg=#{@thm_overlay_0}] %m/%d (%a) %H:%M "
-
-      run-shell ${pkgs.tmuxPlugins.cpu.rtp}
-      run-shell ${pkgs.tmuxPlugins.battery.rtp}
-      run-shell ${pkgs.tmuxPlugins.online-status.rtp}
-
-      bind v split-window -h -c "#{pane_current_path}"
-      bind "|" split-window -h -c "#{pane_current_path}"
-      bind "-" split-window -v -c "#{pane_current_path}"
-
-      unbind s
-      bind S choose-tree -Zs
-
-      bind T run-shell "sesh connect \"\$({ sesh list -i; ghq list -p | grep -v -- '-worktrees/' | sed \"s|^\$HOME|~|\"; } | awk '!seen[\$NF]++' | fzf-tmux -p 60%,60% --ansi --no-sort --reverse --border-label ' sesh ' --color=bg:-1,bg+:-1,gutter:-1,hl:#cba6f7,hl+:#cba6f7:bold,fg:#cdd6f4,fg+:#cdd6f4:bold,prompt:#89b4fa,pointer:#f38ba8,marker:#a6e3a1,border:#89b4fa,label:#89b4fa)\""
-
-      bind h select-pane -L
-      bind j select-pane -D
-      bind k select-pane -U
-      bind l select-pane -R
-
-      bind -r H resize-pane -L 5
-      bind -r J resize-pane -D 5
-      bind -r K resize-pane -U 5
-      bind -r L resize-pane -R 5
-
-      bind -T copy-mode-vi v send -X begin-selection
-      bind -T copy-mode-vi V send -X select-line
-      bind -T copy-mode-vi C-v send -X rectangle-toggle
-      bind -T copy-mode-vi y send -X copy-pipe-and-cancel "pbcopy"
-      bind -T copy-mode-vi Y send -X copy-line
-      bind -T copy-mode-vi Enter send -X copy-pipe-and-cancel "pbcopy"
-      bind -T copy-mode-vi MouseDragEnd1Pane send -X copy-pipe-and-cancel "pbcopy"
-      bind-key C-p paste-buffer
-    '';
-  };
-
-  home.packages = [ pkgs.sesh ];
+  home.packages = [ pkgs.tmux pkgs.sesh ];
 }


### PR DESCRIPTION
## Summary
- https://github.com/hiroppy/tmux-agent-sidebar を試すため、tmux の設定管理方法を変更
- `programs.tmux` (Home Manager) による tmux.conf 生成をやめ、`config/.config/tmux/tmux.conf` をプレーンなファイルとして symlink する方式に変更
- プラグイン管理を Nix (`pkgs.tmuxPlugins`) から TPM (tmux-plugins/tpm) に切り替え、既存プラグイン(sensible, yank, catppuccin, resurrect, continuum, cpu, battery, online-status)に加えて `hiroppy/tmux-agent-sidebar` を追加
- TPM 本体は `home.activation` で初回のみ `~/.tmux/plugins/tpm` に clone するようにした
- status-right のシェルスクリプト(ssid, git-status)は `pkgs.writeShellScript` から `config/.config/tmux/scripts/*.sh` への切り出しに変更
- tmux-agent-sidebar の Claude Code plugin (marketplace source: directory) を `config/.claude/settings.json` の `extraKnownMarketplaces`/`enabledPlugins` に追加し、`make claude-code` の対象に含めた
  - Makefile の抽出 jq が `.source.repo` しか見ておらず directory 形式の marketplace を無視していたため `.repo // .path` にフォールバックするよう修正
- `~/.claude/settings.json` を symlink から「初回のみコピーする書き込み可能ファイル」に変更
  - symlink のままだと `claude plugin install` が settings.json への書き込みを試みて `EACCES`(Nix store が read-only)で失敗し、新規プラグインの install が完了しない問題があったため

## 適用後の手順
1. `make nix` で symlink 反映 + TPM clone + `~/.claude/settings.json` の初回配置
2. tmux を起動し `prefix + I` (C-t I) でプラグインをインストール(この時点で `~/.tmux/plugins/tmux-agent-sidebar` が生成される)
3. `make claude-code` で tmux-agent-sidebar の marketplace 登録 + plugin install

注意: `~/.claude/settings.json` は初回配置後は dotfiles と自動同期しなくなる。dotfiles 側の変更を反映したい場合は `~/.claude/settings.json` を削除してから `make nix` を再実行する。

## Test plan
- [x] `nix build ./nix#homeConfigurations.ci-x86_64-linux.activationPackage` は本環境(aarch64-darwin)ではクロスビルド不可のため未実施(CI で確認)
- [x] flake に一時的に aarch64-darwin 向け設定を追加してローカルでビルド → symlink 先の tmux.conf / scripts (実行権限付き) / TPM clone 用 activation script / settings.json の初回コピー用 activation script が期待通り生成されることを確認済み(検証用の変更はコミットに含めていない)
- [x] `jq` 抽出ロジックが github repo / directory path どちらの marketplace source からも値を取れることを確認
- [x] 実機で `claude plugin install tmux-agent-sidebar@hiroppy` が symlink 起因の EACCES で失敗することを確認し、原因を特定
- [ ] `~/.claude/settings.json` を実ファイル化した状態で `make nix` → `prefix+I` → `make claude-code` → tmux-agent-sidebar の動作確認(ユーザー側で実施)