### PR TITLE
chore: claude code の default model 設定を削除する

### DIFF
--- a/config/.claude/settings.json
+++ b/config/.claude/settings.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "includeCoAuthoredBy": false,
-  "model": "sonnet",
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
   },


### PR DESCRIPTION
## Summary
- `config/.claude/settings.json` の `model: sonnet` 設定を削除し、Claude Code のデフォルトモデル指定をなくす

## Test plan
- `make nix` を実行し、`~/.claude/settings.json` に反映されることを確認