### PR TITLE
fix: delta の diff 背景色が明るすぎる問題を修正する

### DIFF
--- a/config/.gitconfig
+++ b/config/.gitconfig
@@ -30,6 +30,10 @@
 [color]
 	ui = true
 
+[delta]
+	dark = true
+	syntax-theme = Solarized (dark)
+
 [push]
 	default = simple
 	autoSetupRemote = true


### PR DESCRIPTION
## 問題

lazygit の diff 表示 (delta) の背景色が明るいパステルピンク/グリーンで眩しい。

## 原因

`config/.zsh/exports.zsh` の `BAT_THEME="Solarized (light)"` を delta が拾い、light モードと判定していた。

## 対応

`config/.gitconfig` に `[delta]` セクションを追加し、dark モードと dark 系 syntax-theme を明示する。git config は BAT_THEME 環境変数より優先されるため、bat 側の設定はそのまま維持できる。

適用後の diff 背景色: `rgb(255,224,224)` → `rgb(63,0,1)` (削除行) / `rgb(0,40,0)` (追加行)