### PR TITLE
feat: add hunk 0.19.0 and its in-diff search extension

### DIFF
--- a/config/.claude/skills/hunk-review/SKILL.md
+++ b/config/.claude/skills/hunk-review/SKILL.md
@@ -1,0 +1,8 @@
+---
+description: 起動中の Hunk セッションを操作して diff をレビューする
+---
+
+Load the Hunk skill and use it for this review. Run `hunk skill path` to get the skill path.
+
+- TUI はユーザーのものなので、`hunk diff` / `hunk show` は直接実行しない
+- セッションが見つからない場合は、ユーザーにターミナルで Hunk を起動してもらう

--- a/config/.config/hunk/config.toml
+++ b/config/.config/hunk/config.toml
@@ -1,0 +1,1 @@
+theme = "solarized-dark"

--- a/config/.config/hunk/config.toml
+++ b/config/.config/hunk/config.toml
@@ -7,3 +7,8 @@ watch = true
 
 # Home Manager が read-only symlink を張るため、TUI からは保存できない
 prompt_save_view_preferences = false
+
+# built-in はキー競合に勝つため、"/" を extension に渡すには明示的な指定が必要
+[keybindings]
+"hunk-less-search.find" = "/"
+"hunk.review.focusFilter" = "F"

--- a/config/.config/hunk/config.toml
+++ b/config/.config/hunk/config.toml
@@ -1,1 +1,9 @@
 theme = "solarized-dark"
+mode = "stack"
+wrap_lines = true
+agent_notes = true
+cursor_line = "number"
+watch = true
+
+# Home Manager が read-only symlink を張るため、TUI からは保存できない
+prompt_save_view_preferences = false

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -18,6 +18,7 @@
     ./programs/yabai.nix
     ./programs/git-worktree-runner.nix
     ./programs/lazygit.nix
+    ./programs/hunk.nix
     ./programs/redis.nix
   ];
 

--- a/nix/pkgs/hunk/package.nix
+++ b/nix/pkgs/hunk/package.nix
@@ -1,0 +1,162 @@
+{
+  lib,
+  stdenv,
+  bun,
+  fetchFromGitHub,
+  nix-update-script,
+  versionCheckHook,
+  writableTmpDirAsHomeHook,
+}:
+
+let
+  pname = "hunk";
+  version = "0.19.0";
+
+  src = fetchFromGitHub {
+    owner = "modem-dev";
+    repo = "hunk";
+    tag = "v${version}";
+    hash = "sha256-PWblqDS86PaSl5ToFawCNGTxmrWcmoBAfq8R5lMDbyk=";
+  };
+
+  node_modules = stdenv.mkDerivation {
+    pname = "${pname}-node_modules";
+    inherit version src;
+
+    nativeBuildInputs = [
+      bun
+      writableTmpDirAsHomeHook
+    ];
+
+    dontConfigure = true;
+
+    buildPhase = ''
+      runHook preBuild
+
+      export BUN_INSTALL_CACHE_DIR=$(mktemp -d)
+      bun install \
+        --cpu="*" \
+        --frozen-lockfile \
+        --ignore-scripts \
+        --no-progress \
+        --os="*"
+
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out
+      cp -R node_modules $out
+      find packages -type d -name node_modules -exec cp -R --parents {} $out \;
+
+      runHook postInstall
+    '';
+
+    dontFixup = true;
+
+    outputHash = "sha256-Ixsv2wXb39kSRck9ZbjJjRlzn4KS2fkfl3v4MEeD7cE=";
+    outputHashMode = "recursive";
+  };
+in
+stdenv.mkDerivation {
+  inherit pname version src;
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    bun
+    writableTmpDirAsHomeHook
+  ];
+
+  # Teach `hunk skill path` to find the FHS layout under share/skills/$pname
+  # (https://github.com/NixOS/nixpkgs/issues/547426) instead of $out/skills.
+  postPatch = ''
+    substituteInPlace src/core/paths.ts \
+      --replace-fail \
+        'join("node_modules", "hunkdiff", skillRelativePath),' \
+        'join("node_modules", "hunkdiff", skillRelativePath),
+    join("share", "skills", "hunk", name, "SKILL.md"),'
+  '';
+
+  configurePhase = ''
+    runHook preConfigure
+
+    cp -R ${node_modules}/. .
+    chmod -R u+w node_modules
+    find packages -type d -name node_modules -exec chmod -R u+w {} \;
+
+    runHook postConfigure
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    mkdir -p .bun-tmp .bun-install
+    BUN_TMPDIR=$PWD/.bun-tmp \
+    BUN_INSTALL=$PWD/.bun-install \
+      bun build --compile \
+        --no-compile-autoload-bunfig \
+        --no-compile-autoload-dotenv \
+        src/main.tsx \
+        --outfile hunk
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 hunk $out/bin/hunk
+    mkdir -p $out/share/skills/hunk
+    cp -R skills/hunk-review skills/hunk-extensions $out/share/skills/hunk/
+
+    runHook postInstall
+  '';
+
+  dontFixup = true;
+  dontStrip = true;
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    writableTmpDirAsHomeHook
+  ];
+  versionCheckProgramArg = "--version";
+
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    $out/bin/hunk --version | grep -F ${version}
+    test -f "$($out/bin/hunk skill path)"
+    test -f "$($out/bin/hunk skill path hunk-extensions)"
+
+    runHook postInstallCheck
+  '';
+
+  passthru = {
+    inherit node_modules;
+    updateScript = nix-update-script {
+      extraArgs = [
+        "--subpackage"
+        "node_modules"
+      ];
+    };
+  };
+
+  meta = {
+    description = "Terminal diff viewer for agentic changesets";
+    homepage = "https://github.com/modem-dev/hunk";
+    changelog = "https://github.com/modem-dev/hunk/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    mainProgram = "hunk";
+    maintainers = with lib.maintainers; [
+      MarkusZoppelt
+      kaynetik
+    ];
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    sourceProvenance = [ lib.sourceTypes.fromSource ];
+  };
+}

--- a/nix/programs/hunk.nix
+++ b/nix/programs/hunk.nix
@@ -1,0 +1,7 @@
+{ pkgs, ... }:
+
+{
+  home.packages = [ pkgs.hunk ];
+
+  home.file.".config/hunk/config.toml".source = ../../config/.config/hunk/config.toml;
+}

--- a/nix/programs/hunk.nix
+++ b/nix/programs/hunk.nix
@@ -1,7 +1,23 @@
 { pkgs, ... }:
 
+let
+  # nixpkgs の hunk は 0.18.0 で止まっている（bot の自動更新が postPatch の
+  # パターン不一致で失敗している）。extension API v5 を要求する extension を
+  # 使うため 0.19.0 の derivation を自前で持つ。nixpkgs が追いついたら削除する
+  hunk = pkgs.callPackage ../pkgs/hunk/package.nix { };
+
+  # diff の内容を less 風に検索する extension。依存は devDependencies だけなので
+  # checkout をそのまま置けば動く
+  hunk-less-search = pkgs.fetchFromGitHub {
+    owner = "elucid";
+    repo = "hunk-less-search";
+    rev = "787a6d4a5d6c075740d02bb71d45d0aba707d204";
+    hash = "sha256-JOV/f148SpfFDGp1FvXSG26J6zLn4tMqAAmGgMdyS3Y=";
+  };
+in
 {
-  home.packages = [ pkgs.hunk ];
+  home.packages = [ hunk ];
 
   home.file.".config/hunk/config.toml".source = ../../config/.config/hunk/config.toml;
+  home.file.".config/hunk/extensions/hunk-less-search".source = hunk-less-search;
 }

--- a/nix/programs/hunk.nix
+++ b/nix/programs/hunk.nix
@@ -4,6 +4,7 @@ let
   # nixpkgs の hunk は 0.18.0 で止まっている（bot の自動更新が postPatch の
   # パターン不一致で失敗している）。extension API v5 を要求する extension を
   # 使うため 0.19.0 の derivation を自前で持つ。nixpkgs が追いついたら削除する
+  # https://github.com/NixOS/nixpkgs/pull/554129
   hunk = pkgs.callPackage ../pkgs/hunk/package.nix { };
 
   # diff の内容を less 風に検索する extension。依存は devDependencies だけなので


### PR DESCRIPTION
## Why

Manage [hunk](https://github.com/modem-dev/hunk) — a review-first terminal diff viewer for agent-authored changesets — declaratively: the package, its config, and its extension.

Searching diff *contents* needs extension API v5 (hunk 0.19.0 or later), but nixpkgs is still on 0.18.0: the r-ryantm bot's automatic update breaks on an upstream refactor. So keep an updated derivation here for the time being.

- Upstream fix: `https://github.com/NixOS/nixpkgs/pull/554129`

## What

- `nix/pkgs/hunk/package.nix`: the nixpkgs derivation, updated to 0.19.0. Drop it and go back to `pkgs.hunk` once the upstream PR lands
- `nix/programs/hunk.nix`: installs that derivation and symlinks `~/.config/hunk/config.toml` plus the extension
  - The extension is [hunk-less-search](https://github.com/elucid/hunk-less-search), which searches diff contents with a `less`-style `/` prompt. It has no runtime dependencies, so the checkout is placed as-is
- `config/.config/hunk/config.toml`: theme is `solarized-dark` to match the existing delta config, along with layout / wrap / agent notes / cursor line / watch
  - Built-ins win key conflicts, so `[keybindings]` hands `/` to the extension explicitly and moves the file filter to `F`
  - Home Manager symlinks the file read-only, so the TUI cannot save view preferences; `prompt_save_view_preferences = false` disables that prompt
- `config/.claude/skills/hunk-review/SKILL.md`: a thin wrapper skill that loads hunk's own bundled skill (`hunk skill path`)

## Verification

- `nix build ./nix#homeConfigurations.ci-x86_64-linux.activationPackage --dry-run` succeeds (same path as CI)
- Built hunk 0.19.0 on aarch64-darwin; `--version` and both `hunk skill path` lookups pass, including the install check
- hunk starts without config parse errors with the added `config.toml` (verified against a control: injecting an invalid key does make it exit with an error)
- With the extension loaded, hunk starts and shows Extensions in the menu bar

### Not verified

- Whether pressing `/` actually searches has not been verified, since it needs interactive TUI input. Worth checking by hand after `make nix`
