### PR TITLE
feat: ollama を Home Manager 構成に追加する

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -20,6 +20,7 @@
     ./programs/lazygit.nix
     ./programs/hunk.nix
     ./programs/redis.nix
+    ./programs/ollama.nix
   ];
 
   home.stateVersion = "24.05";

--- a/nix/programs/ollama.nix
+++ b/nix/programs/ollama.nix
@@ -1,0 +1,27 @@
+{ config, pkgs, lib, ... }:
+
+let
+  logDir = "${config.home.homeDirectory}/.local/state/ollama";
+in
+{
+  home.packages = [ pkgs.ollama ];
+
+  home.activation.ollamaDirs = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+    run mkdir -p ${logDir}
+  '';
+
+  launchd.agents.ollama = {
+    enable = true;
+    config = {
+      ProgramArguments = [ "${pkgs.ollama}/bin/ollama" "serve" ];
+      RunAtLoad = true;
+      KeepAlive = true;
+      EnvironmentVariables = {
+        HOME = config.home.homeDirectory;
+        OLLAMA_HOST = "127.0.0.1:11434";
+      };
+      StandardOutPath = "${logDir}/ollama.log";
+      StandardErrorPath = "${logDir}/ollama.log";
+    };
+  };
+}


### PR DESCRIPTION
## 概要

ollama を Nix (Home Manager) で管理する構成を追加する。

## 変更内容

- `nix/programs/ollama.nix` を新規追加
  - `pkgs.ollama` (0.32.6) をインストール
  - `launchd.agents.ollama` で `ollama serve` を常駐させる（`RunAtLoad` / `KeepAlive`）
  - ログは `~/.local/state/ollama/ollama.log`
- `nix/home.nix` の imports に追加

CLI ツールなので Brewfile ではなく Nix 側に置き、サービス常駐は既存の `redis.nix` と同じパターンに揃えた。

## 動作確認

- `homeConfigurations.default.activationPackage` (aarch64-darwin) のビルド成功
- `homeConfigurations.ci-x86_64-linux.activationPackage` の評価成功

## 補足

nixpkgs の ollama は `aarch64-darwin` のみ対応で `x86_64-darwin` は非対応（Intel Mac では使えない）。