### PR TITLE
feat: 現在のブランチのPRをブラウザで開く open-pr skill を追加する

### DIFF
--- a/config/.claude/skills/open-pr/SKILL.md
+++ b/config/.claude/skills/open-pr/SKILL.md
@@ -1,0 +1,11 @@
+---
+description: 現在のブランチのPRをブラウザで開く
+disable-model-invocation: true
+---
+
+現在のブランチに紐づくPRをブラウザで開きます。
+
+## 手順
+
+1. `gh pr view --web` を実行する
+2. PRが存在しない場合はその旨を伝えるだけにとどめ、PRの作成は行わない

--- a/config/.claude/skills/open-pr/SKILL.md
+++ b/config/.claude/skills/open-pr/SKILL.md
@@ -1,11 +1,11 @@
 ---
 description: 現在のブランチのPRをブラウザで開く
+allowed-tools: Bash(gh pr view:*)
 disable-model-invocation: true
 ---
 
-現在のブランチに紐づくPRをブラウザで開きます。
+現在のブランチに紐づくPRをブラウザで開きました。
 
-## 手順
+実行結果: !`gh pr view --web 2>&1`
 
-1. `gh pr view --web` を実行する
-2. PRが存在しない場合はその旨を伝えるだけにとどめ、PRの作成は行わない
+上の結果を1行で報告するだけにとどめる。PRが存在しない場合もその旨を伝えるだけで、PRの作成は行わない。


### PR DESCRIPTION
## Why

- 作業中のセッションから今のブランチの PR をブラウザで開きたい場面が多く、毎回 `gh pr view --web` を打つのが手間だった

## What

- `config/.claude/skills/open-pr/SKILL.md` を追加
- `gh pr view --web` を実行するだけの skill。PR が存在しない場合は作成せず、その旨を伝えるだけにとどめる
- `disable-model-invocation: true` なので `/open-pr` の明示実行のみ
- skills ディレクトリごと symlink されているため nix 側の変更は不要