### PR TITLE
chore: crit を Brewfile に追加する

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -27,6 +27,7 @@ cask "wezterm"
 brew "googleworkspace-cli"
 
 brew "aqua"
+brew "crit"
 brew "libyaml"
 brew "xcodes"
 


### PR DESCRIPTION
## 概要

エージェントのプラン/コードをローカルでレビューする CLI ツール [crit](https://crit.md/) を Brewfile に追加。

CLI は Nix 優先の方針だが、nixpkgs に crit のパッケージが存在しないため Homebrew で管理する。

## 動作確認

- `brew bundle list --file=Brewfile` で crit が列挙されること
- `brew install crit` → `crit --version` が 0.19.1 を返すこと