### PR TITLE
feat: Chrome の「垂直タブを閉じる」を option+ctrl+b に割り当てる

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -21,6 +21,7 @@
     ./programs/hunk.nix
     ./programs/crit.nix
     ./programs/redis.nix
+    ./programs/chrome.nix
   ];
 
   home.stateVersion = "24.05";

--- a/nix/programs/chrome.nix
+++ b/nix/programs/chrome.nix
@@ -1,0 +1,9 @@
+{ lib, pkgs, ... }:
+
+{
+  config = lib.mkIf pkgs.stdenv.isDarwin {
+    targets.darwin.defaults."com.google.Chrome".NSUserKeyEquivalents = {
+      "垂直タブを閉じる" = "^b";
+    };
+  };
+}

--- a/nix/programs/chrome.nix
+++ b/nix/programs/chrome.nix
@@ -3,7 +3,7 @@
 {
   config = lib.mkIf pkgs.stdenv.isDarwin {
     targets.darwin.defaults."com.google.Chrome".NSUserKeyEquivalents = {
-      "垂直タブを閉じる" = "^b";
+      "垂直タブを閉じる" = "~^b";
     };
   };
 }


### PR DESCRIPTION
macOS の App Shortcuts (`NSUserKeyEquivalents`) を Home Manager の `targets.darwin.defaults` で宣言的に管理する。

Chrome の「垂直タブを閉じる」を ⇧⌘L から ⌥⌃B に変更。

- Linux CI では `assertPlatform` で落ちるため `lib.mkIf pkgs.stdenv.isDarwin` で囲む
- 反映は `make nix` 後に Chrome を再起動