### PR TITLE
feat: Chrome の垂直タブ閉じるショートカットを英語環境にも対応させる

### DIFF
--- a/nix/programs/chrome.nix
+++ b/nix/programs/chrome.nix
@@ -4,6 +4,7 @@
   config = lib.mkIf pkgs.stdenv.isDarwin {
     targets.darwin.defaults."com.google.Chrome".NSUserKeyEquivalents = {
       "垂直タブを閉じる" = "~^b";
+      "Collapse Vertical Tabs" = "~^b";
     };
   };
 }


### PR DESCRIPTION
スクリーンショットの通り、英語環境ではメニュー項目名が `Collapse Vertical Tabs` になるため、`NSUserKeyEquivalents` に英語名のエントリを追加して option+ctrl+b がどちらの言語設定でも効くようにする。