### PR TITLE
fix: codex の config.toml を書き込み可能な実ファイルとして配置する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,8 @@ cask "app-name"
 - Place application config files in `config/` directory matching the target location structure
 - Files in `config/` are symlinked to `$HOME/` by Home Manager or manually
 - For Nix-managed programs, prefer using Home Manager's native configuration options
+- ツール自身が設定ファイルに書き戻す場合は `home.file` を使わない。Nix store へのシンボリックリンクは読み取り専用のため書き込みが失敗する。`home.activation` で書き込み可能な実ファイルとしてコピーし、ツールが書き込む区画だけ引き継ぐ
+  - `nix/programs/codex.nix` がこの形。codex は trust したディレクトリを `[projects."<絶対パス>"]` として `config.toml` に書き込むため、コピー時に既存の `[projects]` ブロックを引き継いでいる（trust は完全一致のみで、親ディレクトリからの継承や再帰指定はできない）
 
 ## Memories
 

--- a/nix/programs/codex.nix
+++ b/nix/programs/codex.nix
@@ -1,9 +1,25 @@
-{ pkgs, ... }:
+{ lib, pkgs, ... }:
 
 {
   home.packages = [ pkgs.codex ];
 
   home.file.".codex/AGENTS.md".source = ../../config/.codex/AGENTS.md;
-  home.file.".codex/config.toml".source = ../../config/.codex/config.toml;
   home.file.".codex/prompts".source = ../../config/.codex/prompts;
+
+  home.activation.codexConfig = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+    codexConfig="$HOME/.codex/config.toml"
+
+    codexProjects=""
+    if [ -f "$codexConfig" ]; then
+      codexProjects="$(${pkgs.gawk}/bin/awk '/^\[/ { keep = ($0 ~ /^\[projects[.\]]/) } keep' "$codexConfig")"
+    fi
+
+    $DRY_RUN_CMD mkdir -p "$HOME/.codex"
+    $DRY_RUN_CMD rm -f "$codexConfig"
+    $DRY_RUN_CMD install -m 600 ${../../config/.codex/config.toml} "$codexConfig"
+
+    if [ -n "$codexProjects" ]; then
+      printf '\n%s\n' "$codexProjects" | $DRY_RUN_CMD ${pkgs.coreutils}/bin/tee -a "$codexConfig" > /dev/null
+    fi
+  '';
 }


### PR DESCRIPTION
## Why

- https://github.com/sora-ichigo/dotfiles/pull/91 で `~/.codex/config.toml` を `home.file` で配置したが、これは Nix store への読み取り専用シンボリックリンクになるため、codex が設定を書き戻せず起動時に失敗していた

```
Failed to set trust for /Users/ichigo/ghq/github.com/sora-ichigo/dotfiles: config/batchWrite
failed in TUI: failed to persist config at /nix/store/...-hm_config.toml (code -32603)
```

- codex は trust したディレクトリを `[projects."<絶対パス>"]` として `config.toml` に書き込む。他にも `/model` でのモデル変更、警告の非表示、`codex mcp add` が同じファイルに書き込むため、読み取り専用では機能しない
- trust の事前設定で回避することはできない。trust のキーは解決された project root の絶対パスの完全一致で、親ディレクトリからの継承や再帰指定はできず、`~/ghq` 配下をまとめて trust する手段が無い

## What

- `~/.codex/config.toml` を `home.file` ではなく `home.activation` で書き込み可能な実ファイル（mode 600）としてコピーする
- コピー時に、既存ファイルの `[projects]` ブロックだけを抽出して引き継ぐ
  - trust は `make nix` をまたいで残る
  - それ以外の codex による書き込み（モデル変更など）はリポジトリの内容で上書きされ、リポジトリが source of truth のまま保たれる
  - リポジトリの作業ツリーは汚れない
- `AGENTS.md` と `prompts` は codex が書き込まないため `home.file` のまま
- この判断を `CLAUDE.md` の Configuration Files Management に記録する

`auth.json`・セッション・履歴は別ファイルのため、`codex login` の結果はこの入れ替えの影響を受けない。

### 確認したこと

- 現象の再現: nix store を指すシンボリックリンクに対する書き込みが `Permission denied` で失敗すること
- trust の解決範囲: project 直下の `.codex/config.toml` が読まれるかで判定し、完全一致のときのみ trust されること
- activation スクリプトの挙動: 読み取り専用リンクからの置換、`[projects]` の引き継ぎ、それ以外の書き込みの破棄
