### PR TITLE
fix: codex の承認スキップをやめ serena MCP を削除する

### DIFF
--- a/config/.codex/config.toml
+++ b/config/.codex/config.toml
@@ -2,7 +2,7 @@ model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 hide_agent_reasoning = true
 
-approval_policy = "never"
+approval_policy = "on-request"
 sandbox_mode = "workspace-write"
 
 notify = ["bash", "-lc", "afplay /System/Library/Sounds/Ping.aiff"]
@@ -13,10 +13,6 @@ writable_roots = ["~/.obsidian/igsr5/01_dailynotes"]
 
 [tools]
 web_search = true
-
-[mcp_servers.serena]
-command = "uvx"
-args = ["--from", "git+https://github.com/oraios/serena", "serena", "start-mcp-server", "--context", "codex"]
 
 [mcp_servers.context7]
 command = "npx"

--- a/config/.gitignore_global
+++ b/config/.gitignore_global
@@ -1,4 +1,3 @@
-.serena
 .mcp.json
 .DS_Store
 .AppleDouble


### PR DESCRIPTION
## 変更内容

- codex の `approval_policy` を `never` から `on-request` に変更。sandbox 外の操作や書き込みで承認を求めるようになる（`sandbox_mode = "workspace-write"` は据え置き）
- codex の `[mcp_servers.serena]` を削除
- serena を使わなくなったので `.gitignore_global` の `.serena` を削除

Claude Code 側は `config/.claude/mcp.json` に serena の登録がすでになく、変更不要。

## 適用

```
make nix
```