### PR TITLE
fix: gemini からも serena MCP を削除する

### DIFF
--- a/config/.gemini/settings.json
+++ b/config/.gemini/settings.json
@@ -1,16 +1,5 @@
 {
   "mcpServers": {
-    "serena": {
-      "command": "uvx",
-      "args": [
-        "--from",
-        "git+https://github.com/oraios/serena",
-        "serena",
-        "start-mcp-server",
-        "--context",
-        "ide-assistant"
-      ]
-    },
     "context7": {
       "command": "npx",
       "args": ["-y", "@upstash/context7-mcp@latest"]


### PR DESCRIPTION
## Why

- https://github.com/sora-ichigo/dotfiles/pull/93 で codex から serena MCP を削除したが、並行して作業していた https://github.com/sora-ichigo/dotfiles/pull/94 が削除前の codex 構成をベースにしていたため、Gemini CLI 側に serena が残ってしまっていた

## What

- `config/.gemini/settings.json` の `mcpServers` から serena を削除し、codex と構成を揃える
